### PR TITLE
perf: optimize range API with streaming & prefetch

### DIFF
--- a/e2e/indexer.e2e-spec.ts
+++ b/e2e/indexer.e2e-spec.ts
@@ -2,7 +2,7 @@ import { UTXO, WalletHelper, AddressType } from '@e2e/helpers/wallet.helper';
 import { transactionToEntity } from '@e2e/helpers/common.helper';
 import { initialiseDep } from '@e2e/setup';
 import { ApiHelper } from '@e2e/helpers/api.helper';
-import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
+import { encodeSilentBlock } from '@/silent-blocks/silent-block-encoder';
 import { btcToSats } from '@/common/common';
 
 describe('Indexer', () => {
@@ -58,11 +58,7 @@ describe('Indexer', () => {
                 outputs,
             );
 
-            const silentBlock = new SilentBlocksService(
-                {} as any,
-                {} as any,
-                {} as any,
-            ).encodeSilentBlock([transformedTransaction]);
+            const silentBlock = encodeSilentBlock([transformedTransaction]);
 
             // remove this once Web Socket is implemented
             await new Promise((resolve) => setTimeout(resolve, 15000));
@@ -122,11 +118,7 @@ describe('Indexer', () => {
             },
         );
 
-        const silentBlock = new SilentBlocksService(
-            {} as any,
-            {} as any,
-            {} as any,
-        ).encodeSilentBlock([]);
+        const silentBlock = encodeSilentBlock([]);
 
         expect(response.data).toEqual(silentBlock);
     });

--- a/src/block-data-providers/base-block-data-provider.abstract.ts
+++ b/src/block-data-providers/base-block-data-provider.abstract.ts
@@ -25,6 +25,12 @@ export abstract class BaseBlockDataProvider<OperationState> {
         protected readonly storageService: StorageService,
     ) {}
 
+    /** Keeps a look-ahead rejection from going unhandled if it is never awaited. */
+    protected prefetch<T>(promise: Promise<T>): Promise<T> {
+        promise.catch(() => undefined);
+        return promise;
+    }
+
     async indexTransaction(
         txid: string,
         vin: TransactionInput[],

--- a/src/block-data-providers/base-block-data-provider.abstract.ts
+++ b/src/block-data-providers/base-block-data-provider.abstract.ts
@@ -10,6 +10,7 @@ import { ConfigService } from '@nestjs/config';
 import { BlockStateService } from '@/block-state/block-state.service';
 import { BatchWriter } from '@/storage/batch-writer';
 import { StorageService } from '@/storage/storage.service';
+import { TransactionData } from '@/storage/interfaces';
 
 export abstract class BaseBlockDataProvider<OperationState> {
     protected readonly eventEmitter: EventEmitter2 = new EventEmitter2();
@@ -32,7 +33,10 @@ export abstract class BaseBlockDataProvider<OperationState> {
         blockHash: string,
         blockTime: number,
         batch: BatchWriter,
-    ): Promise<Map<string, { pubKey: string; value: number }>> {
+    ): Promise<{
+        pendingOutputs: Map<string, { pubKey: string; value: number }>;
+        txData: TransactionData | null;
+    }> {
         return this.indexerService.index(
             txid,
             vin,

--- a/src/block-data-providers/bitcoin-core/provider.ts
+++ b/src/block-data-providers/bitcoin-core/provider.ts
@@ -132,9 +132,19 @@ export class BitcoinCoreProvider
             let height =
                 ((await this.traceReorg()) ?? state.indexedBlockHeight) + 1;
 
+            let nextBlock: Promise<{
+                transactions: Transaction[];
+                blockHash: string;
+                blockTime: number;
+            }> | null = this.processBlock(height, verbosityLevel);
+
             for (height; height <= tipHeight; height++) {
-                const { transactions, blockHash, blockTime } =
-                    await this.processBlock(height, verbosityLevel);
+                const { transactions, blockHash, blockTime } = await nextBlock;
+
+                nextBlock =
+                    height + 1 <= tipHeight
+                        ? this.processBlock(height + 1, verbosityLevel)
+                        : null;
 
                 await this.dbTransactionService.execute(async (batch) => {
                     const spentOutpoints: [string, number][] = [];

--- a/src/block-data-providers/bitcoin-core/provider.ts
+++ b/src/block-data-providers/bitcoin-core/provider.ts
@@ -32,6 +32,8 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { INDEXED_BLOCK_EVENT } from '@/common/events';
 import { btcToSats } from '@/common/common';
 import { StorageService } from '@/storage/storage.service';
+import { encodeSilentBlock } from '@/silent-blocks/silent-block-encoder';
+import { TransactionData } from '@/storage/interfaces';
 
 @Injectable()
 export class BitcoinCoreProvider
@@ -140,11 +142,12 @@ export class BitcoinCoreProvider
                         string,
                         { pubKey: string; value: number }
                     >();
+                    const blockTxData: TransactionData[] = [];
 
                     for (const transaction of transactions) {
                         const { txid, vin, vout, blockHeight, blockHash } =
                             transaction;
-                        const saved = await this.indexTransaction(
+                        const result = await this.indexTransaction(
                             txid,
                             vin,
                             vout,
@@ -154,9 +157,10 @@ export class BitcoinCoreProvider
                             batch,
                         );
 
-                        for (const [k, v] of saved) {
+                        for (const [k, v] of result.pendingOutputs) {
                             pendingOutputs.set(k, v);
                         }
+                        if (result.txData) blockTxData.push(result.txData);
 
                         for (const input of vin) {
                             spentOutpoints.push([input.txid, input.vout]);
@@ -167,6 +171,12 @@ export class BitcoinCoreProvider
                         batch,
                         spentOutpoints,
                         pendingOutputs,
+                    );
+
+                    this.storageService.saveSilentBlock(
+                        batch,
+                        height,
+                        encodeSilentBlock(blockTxData),
                     );
 
                     state.indexedBlockHeight = height;

--- a/src/block-data-providers/bitcoin-core/provider.ts
+++ b/src/block-data-providers/bitcoin-core/provider.ts
@@ -136,14 +136,18 @@ export class BitcoinCoreProvider
                 transactions: Transaction[];
                 blockHash: string;
                 blockTime: number;
-            }> | null = this.processBlock(height, verbosityLevel);
+            }> | null = this.prefetch(
+                this.processBlock(height, verbosityLevel),
+            );
 
             for (height; height <= tipHeight; height++) {
                 const { transactions, blockHash, blockTime } = await nextBlock;
 
                 nextBlock =
                     height + 1 <= tipHeight
-                        ? this.processBlock(height + 1, verbosityLevel)
+                        ? this.prefetch(
+                              this.processBlock(height + 1, verbosityLevel),
+                          )
                         : null;
 
                 await this.dbTransactionService.execute(async (batch) => {

--- a/src/block-data-providers/esplora/provider.spec.ts
+++ b/src/block-data-providers/esplora/provider.spec.ts
@@ -1,0 +1,69 @@
+import { ConfigService } from '@nestjs/config';
+import { EsploraProvider } from '@/block-data-providers/esplora/provider';
+
+/**
+ * A coinbase-only block runs zero batches in processBlock (the loop starts at
+ * lastProcessedTxIndex + 1 === txids.length), so the height used to be saved as
+ * a silent block and broadcast without ever being marked done — a restart then
+ * reprocessed and re-emitted it.
+ */
+describe('Esplora Provider coinbase-only block', () => {
+    it('commits block state for a block with only a coinbase tx', async () => {
+        const config = {
+            'esplora.batchSize': 10,
+            'esplora.url': 'http://localhost:3000',
+            'app.network': 'regtest',
+            'app.requestRetry': {},
+        };
+
+        const saveOperationState = jest.fn();
+        const saveBlockState = jest.fn();
+        const saveSilentBlock = jest.fn();
+        const storageService = {
+            saveOperationState,
+            saveBlockState,
+            saveSilentBlock,
+            getTransactionsByBlockHeight: jest.fn().mockResolvedValue([]),
+        };
+        const emit = jest.fn();
+
+        const provider = new EsploraProvider(
+            { get: (k: string) => config[k] } as unknown as ConfigService,
+            {} as any,
+            {} as any,
+            {} as any,
+            {
+                execute: jest.fn((fn) => fn({} as any)),
+            } as any,
+            { emit } as any,
+            storageService as any,
+        );
+
+        jest.spyOn(provider, 'getState').mockResolvedValue({
+            currentBlockHeight: 0,
+            indexedBlockHeight: 99,
+            lastProcessedTxIndex: 0,
+        });
+        // Only the coinbase tx.
+        (provider as any).getTxidsForBlock = jest
+            .fn()
+            .mockResolvedValue(['cb'.repeat(32)]);
+
+        await (provider as any).processBlock(100, 'hash-100');
+
+        expect(saveSilentBlock).toHaveBeenCalled();
+        expect(saveBlockState).toHaveBeenCalledWith(expect.anything(), {
+            blockHeight: 100,
+            blockHash: 'hash-100',
+        });
+        expect(saveOperationState).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.any(String),
+            expect.objectContaining({
+                indexedBlockHeight: 100,
+                lastProcessedTxIndex: 0,
+            }),
+        );
+        expect(emit).toHaveBeenCalledWith(expect.any(String), 100);
+    });
+});

--- a/src/block-data-providers/esplora/provider.ts
+++ b/src/block-data-providers/esplora/provider.ts
@@ -128,11 +128,19 @@ export class EsploraProvider
             let height =
                 ((await this.traceReorg()) ?? state.indexedBlockHeight) + 1;
 
+            let nextBlockHash: Promise<string> | null =
+                this.getBlockHash(height);
+
             for (height; height <= tipHeight; height++) {
-                const blockHash = await this.getBlockHash(height);
+                const blockHash = await nextBlockHash;
                 this.logger.log(
                     `Processing block at height ${height}, hash ${blockHash}`,
                 );
+
+                nextBlockHash =
+                    height + 1 <= tipHeight
+                        ? this.getBlockHash(height + 1)
+                        : null;
 
                 await this.processBlock(height, blockHash);
             }

--- a/src/block-data-providers/esplora/provider.ts
+++ b/src/block-data-providers/esplora/provider.ts
@@ -229,8 +229,6 @@ export class EsploraProvider
                         batch,
                     );
                 });
-
-                this.eventEmitter.emit(INDEXED_BLOCK_EVENT, height);
             } catch (error) {
                 this.logger.error(
                     `Error processing transactions in block at height ${height}, hash ${hash}: ${error.message}`,
@@ -253,6 +251,11 @@ export class EsploraProvider
                 encodeSilentBlock(blockTxData),
             );
         });
+
+        // Emitted once per block, after the blob is stored: a per-batch emit
+        // broadcast the same height repeatedly, each time re-encoding whatever
+        // subset of the block had been committed so far.
+        this.eventEmitter.emit(INDEXED_BLOCK_EVENT, height);
     }
 
     private async getTipHeight(): Promise<number> {

--- a/src/block-data-providers/esplora/provider.ts
+++ b/src/block-data-providers/esplora/provider.ts
@@ -17,6 +17,8 @@ import { DbTransactionService } from '@/db-transaction/db-transaction.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { INDEXED_BLOCK_EVENT } from '@/common/events';
 import { StorageService } from '@/storage/storage.service';
+import { encodeSilentBlock } from '@/silent-blocks/silent-block-encoder';
+import { TransactionData } from '@/storage/interfaces';
 
 @Injectable()
 export class EsploraProvider
@@ -142,6 +144,7 @@ export class EsploraProvider
     private async processBlock(height: number, hash: string) {
         const state = await this.getState();
         const txids = await this.getTxidsForBlock(hash);
+        const allBlockTxData: TransactionData[] = [];
 
         for (
             let i = state.lastProcessedTxIndex + 1;
@@ -152,6 +155,7 @@ export class EsploraProvider
                 i,
                 Math.min(i + this.batchSize, txids.length),
             );
+            const isLastBatch = i + this.batchSize >= txids.length;
 
             try {
                 await this.dbTransactionService.execute(async (batch) => {
@@ -182,7 +186,7 @@ export class EsploraProvider
                                 value: output.value,
                             }));
 
-                            const saved = await this.indexTransaction(
+                            const result = await this.indexTransaction(
                                 txid,
                                 vin,
                                 vout,
@@ -192,9 +196,11 @@ export class EsploraProvider
                                 batch,
                             );
 
-                            for (const [k, v] of saved) {
+                            for (const [k, v] of result.pendingOutputs) {
                                 pendingOutputs.set(k, v);
                             }
+                            if (result.txData)
+                                allBlockTxData.push(result.txData);
                         }, this),
                     );
 
@@ -203,6 +209,14 @@ export class EsploraProvider
                         spentOutpoints,
                         pendingOutputs,
                     );
+
+                    if (isLastBatch) {
+                        this.storageService.saveSilentBlock(
+                            batch,
+                            height,
+                            encodeSilentBlock(allBlockTxData),
+                        );
+                    }
 
                     state.indexedBlockHeight = height;
                     state.lastProcessedTxIndex = i + this.batchSize - 1;

--- a/src/block-data-providers/esplora/provider.ts
+++ b/src/block-data-providers/esplora/provider.ts
@@ -128,8 +128,9 @@ export class EsploraProvider
             let height =
                 ((await this.traceReorg()) ?? state.indexedBlockHeight) + 1;
 
-            let nextBlockHash: Promise<string> | null =
-                this.getBlockHash(height);
+            let nextBlockHash: Promise<string> | null = this.prefetch(
+                this.getBlockHash(height),
+            );
 
             for (height; height <= tipHeight; height++) {
                 const blockHash = await nextBlockHash;
@@ -139,7 +140,7 @@ export class EsploraProvider
 
                 nextBlockHash =
                     height + 1 <= tipHeight
-                        ? this.getBlockHash(height + 1)
+                        ? this.prefetch(this.getBlockHash(height + 1))
                         : null;
 
                 await this.processBlock(height, blockHash);
@@ -152,7 +153,6 @@ export class EsploraProvider
     private async processBlock(height: number, hash: string) {
         const state = await this.getState();
         const txids = await this.getTxidsForBlock(hash);
-        const allBlockTxData: TransactionData[] = [];
 
         for (
             let i = state.lastProcessedTxIndex + 1;
@@ -207,8 +207,6 @@ export class EsploraProvider
                             for (const [k, v] of result.pendingOutputs) {
                                 pendingOutputs.set(k, v);
                             }
-                            if (result.txData)
-                                allBlockTxData.push(result.txData);
                         }, this),
                     );
 
@@ -218,16 +216,10 @@ export class EsploraProvider
                         pendingOutputs,
                     );
 
-                    if (isLastBatch) {
-                        this.storageService.saveSilentBlock(
-                            batch,
-                            height,
-                            encodeSilentBlock(allBlockTxData),
-                        );
-                    }
-
                     state.indexedBlockHeight = height;
-                    state.lastProcessedTxIndex = i + this.batchSize - 1;
+                    state.lastProcessedTxIndex = isLastBatch
+                        ? 0
+                        : i + this.batchSize - 1;
                     await this.setState(
                         state,
                         {
@@ -246,6 +238,21 @@ export class EsploraProvider
                 throw error;
             }
         }
+
+        // Read back from storage, not accumulated in-run: a run that resumed
+        // mid-block would only see part of the block.
+        const blockTxData: TransactionData[] =
+            await this.storageService.getTransactionsByBlockHeight(
+                height,
+                false,
+            );
+        await this.dbTransactionService.execute(async (batch) => {
+            this.storageService.saveSilentBlock(
+                batch,
+                height,
+                encodeSilentBlock(blockTxData),
+            );
+        });
     }
 
     private async getTipHeight(): Promise<number> {

--- a/src/block-data-providers/esplora/provider.ts
+++ b/src/block-data-providers/esplora/provider.ts
@@ -154,18 +154,18 @@ export class EsploraProvider
         const state = await this.getState();
         const txids = await this.getTxidsForBlock(hash);
 
-        for (
-            let i = state.lastProcessedTxIndex + 1;
-            i < txids.length;
-            i += this.batchSize
-        ) {
-            const txBatch = txids.slice(
-                i,
-                Math.min(i + this.batchSize, txids.length),
-            );
-            const isLastBatch = i + this.batchSize >= txids.length;
+        try {
+            for (
+                let i = state.lastProcessedTxIndex + 1;
+                i < txids.length;
+                i += this.batchSize
+            ) {
+                const txBatch = txids.slice(
+                    i,
+                    Math.min(i + this.batchSize, txids.length),
+                );
+                const isLastBatch = i + this.batchSize >= txids.length;
 
-            try {
                 await this.dbTransactionService.execute(async (batch) => {
                     const spentOutpoints: [string, number][] = [];
                     const pendingOutputs = new Map<
@@ -229,28 +229,44 @@ export class EsploraProvider
                         batch,
                     );
                 });
-            } catch (error) {
-                this.logger.error(
-                    `Error processing transactions in block at height ${height}, hash ${hash}: ${error.message}`,
-                );
-                throw error;
             }
-        }
 
-        // Read back from storage, not accumulated in-run: a run that resumed
-        // mid-block would only see part of the block.
-        const blockTxData: TransactionData[] =
-            await this.storageService.getTransactionsByBlockHeight(
-                height,
-                false,
+            // Read back from storage, not accumulated in-run: a run that
+            // resumed mid-block would only see part of the block.
+            const blockTxData: TransactionData[] =
+                await this.storageService.getTransactionsByBlockHeight(
+                    height,
+                    false,
+                );
+            await this.dbTransactionService.execute(async (batch) => {
+                this.storageService.saveSilentBlock(
+                    batch,
+                    height,
+                    encodeSilentBlock(blockTxData),
+                );
+
+                // Committed here too, not only in the batch loop: a
+                // coinbase-only block runs zero batches, so the height would
+                // never be marked done and every restart would reprocess it
+                // and re-emit INDEXED_BLOCK_EVENT for an already-broadcast
+                // block. Same batch as the blob, so the two can't diverge.
+                state.indexedBlockHeight = height;
+                state.lastProcessedTxIndex = 0;
+                await this.setState(
+                    state,
+                    {
+                        blockHeight: height,
+                        blockHash: hash,
+                    },
+                    batch,
+                );
+            });
+        } catch (error) {
+            this.logger.error(
+                `Error processing block at height ${height}, hash ${hash}: ${error.message}`,
             );
-        await this.dbTransactionService.execute(async (batch) => {
-            this.storageService.saveSilentBlock(
-                batch,
-                height,
-                encodeSilentBlock(blockTxData),
-            );
-        });
+            throw error;
+        }
 
         // Emitted once per block, after the blob is stored: a per-batch emit
         // broadcast the same height repeatedly, each time re-encoding whatever

--- a/src/block-state/block-state.service.ts
+++ b/src/block-state/block-state.service.ts
@@ -13,6 +13,7 @@ export class BlockStateService {
     async removeState(state: BlockStateData): Promise<void> {
         const batch = this.storageService.createBatch();
         this.storageService.deleteBlockState(batch, state.blockHeight);
+        this.storageService.deleteSilentBlock(batch, state.blockHeight);
         await this.storageService.deleteTransactionsByBlockHash(
             batch,
             state.blockHash,

--- a/src/common/common.spec.ts
+++ b/src/common/common.spec.ts
@@ -1,4 +1,26 @@
-import { btcToSats, extractPubKeyFromScript } from '@/common/common';
+import {
+    btcToSats,
+    encodeVarInt,
+    extractPubKeyFromScript,
+    varIntSize,
+} from '@/common/common';
+
+// Standard Bitcoin CompactSize reader, used to validate encodeVarInt output.
+const readCompactSize = (
+    buf: Buffer,
+    offset = 0,
+): { value: number; offset: number } => {
+    const first = buf.readUInt8(offset);
+    if (first < 0xfd) return { value: first, offset: offset + 1 };
+    if (first === 0xfd)
+        return { value: buf.readUInt16LE(offset + 1), offset: offset + 3 };
+    if (first === 0xfe)
+        return { value: buf.readUInt32LE(offset + 1), offset: offset + 5 };
+    return {
+        value: Number(buf.readBigUInt64LE(offset + 1)),
+        offset: offset + 9,
+    };
+};
 
 describe('Common', () => {
     it.each([
@@ -212,4 +234,55 @@ describe('Common', () => {
             expect(btcToSats(btc)).toBe(sats);
         },
     );
+
+    it.each([
+        { value: 0, size: 1, description: 'zero (single byte)' },
+        { value: 1, size: 1, description: 'one (single byte)' },
+        { value: 0xfc, size: 1, description: '252 (largest single byte)' },
+        { value: 0xfd, size: 3, description: '253 (smallest 0xfd marker)' },
+        { value: 300, size: 3, description: '300 (busy-block tx count)' },
+        { value: 0xffff, size: 3, description: '65535 (largest 0xfd marker)' },
+        {
+            value: 0x10000,
+            size: 5,
+            description: '65536 (smallest 0xfe marker)',
+        },
+        { value: 0xffffffff, size: 5, description: 'u32 max (0xfe marker)' },
+        {
+            value: 0x100000000,
+            size: 9,
+            description: 'u32 max + 1 (0xff marker)',
+        },
+    ])(
+        'should encode $value as a standard CompactSize: $description',
+        ({ value, size }) => {
+            expect(varIntSize(value)).toBe(size);
+
+            const buf = Buffer.alloc(size);
+            const next = encodeVarInt(value, buf, 0);
+
+            // Returned cursor matches the declared size.
+            expect(next).toBe(size);
+
+            // A standard CompactSize reader recovers the value and consumes
+            // exactly `size` bytes.
+            const decoded = readCompactSize(buf, 0);
+            expect(decoded.value).toBe(value);
+            expect(decoded.offset).toBe(size);
+        },
+    );
+
+    it('should not clobber a following field when writing a multi-byte count', () => {
+        // Reproduces the ≥253 corruption: encode a count, then write a sentinel
+        // immediately after. A correct encoder leaves the count intact.
+        const count = 300;
+        const buf = Buffer.alloc(varIntSize(count) + 1);
+        let cursor = encodeVarInt(count, buf, 0);
+        cursor = buf.writeUInt8(0xab, cursor);
+
+        const decoded = readCompactSize(buf, 0);
+        expect(decoded.value).toBe(count);
+        expect(buf.readUInt8(decoded.offset)).toBe(0xab);
+        expect(cursor).toBe(buf.length);
+    });
 });

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -1,7 +1,42 @@
 import { createHash } from 'crypto';
+import { BadRequestException } from '@nestjs/common';
 import { publicKeyVerify } from 'secp256k1';
 import { NUMS_H, SATS_PER_BTC } from '@/common/constants';
 import * as currency from 'currency.js';
+
+// Height keys are 4-byte big-endian and span ranges encode `endHeight + 1`, so
+// a height outside this bound throws ERR_OUT_OF_RANGE from writeUInt32BE deep
+// inside key-encoding and surfaces as a 500. Reject it at the edge instead.
+export const MAX_INDEXED_HEIGHT = 0xfffffffe;
+
+export const assertHeight = (height: number, name = 'height'): void => {
+    if (
+        !Number.isInteger(height) ||
+        height < 0 ||
+        height > MAX_INDEXED_HEIGHT
+    ) {
+        throw new BadRequestException(
+            `${name} must be an integer between 0 and ${MAX_INDEXED_HEIGHT}`,
+        );
+    }
+};
+
+export const assertHeightRange = (
+    startHeight: number,
+    endHeight: number,
+    maxRange: number,
+): void => {
+    assertHeight(startHeight, 'startHeight');
+    assertHeight(endHeight, 'endHeight');
+    if (endHeight < startHeight) {
+        throw new BadRequestException('endHeight must be >= startHeight');
+    }
+    if (endHeight - startHeight + 1 > maxRange) {
+        throw new BadRequestException(
+            `Range exceeds maximum of ${maxRange} blocks`,
+        );
+    }
+};
 
 export const camelToSnakeCase = (inputString: string) => {
     return inputString

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -129,15 +129,15 @@ export const encodeVarInt = (
         return offset + 1;
     } else if (value <= 0xffff) {
         buffer.writeUInt8(0xfd, offset);
-        buffer.writeUInt16LE(value, offset + 2);
+        buffer.writeUInt16LE(value, offset + 1);
         return offset + 3;
     } else if (value <= 0xffffffff) {
         buffer.writeUInt8(0xfe, offset);
-        buffer.writeUInt32LE(value, offset + 4);
+        buffer.writeUInt32LE(value, offset + 1);
         return offset + 5;
     } else {
         buffer.writeUInt8(0xff, offset);
-        buffer.writeBigUInt64LE(BigInt(value), offset + 8);
+        buffer.writeBigUInt64LE(BigInt(value), offset + 1);
         return offset + 9;
     }
 };

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -12,3 +12,5 @@ export const BITCOIN_CORE_FULL_VERBOSITY_VERSION = 23_0000;
 export const SILENT_PAYMENT_BLOCK_TYPE = 0x00;
 
 export const MAX_BLOCK_RANGE = 50;
+
+export const MAX_SILENT_BLOCK_RANGE = 200;

--- a/src/indexer/indexer.service.ts
+++ b/src/indexer/indexer.service.ts
@@ -36,7 +36,10 @@ export class IndexerService {
         blockHash: string,
         blockTime: number,
         batch: BatchWriter,
-    ): Promise<Map<string, { pubKey: string; value: number }>> {
+    ): Promise<{
+        pendingOutputs: Map<string, { pubKey: string; value: number }>;
+        txData: TransactionData | null;
+    }> {
         const scanResult = this.deriveOutputsAndComputeScanTweak(vin, vout);
         if (scanResult !== null) {
             const { scanTweak, eligibleOutputs } = scanResult;
@@ -49,7 +52,7 @@ export class IndexerService {
                 isSpent: false,
             }));
 
-            const transaction: TransactionData = {
+            const txData: TransactionData = {
                 id: txid,
                 blockHeight,
                 blockHash,
@@ -58,9 +61,13 @@ export class IndexerService {
                 outputs,
             };
 
-            return this.storageService.saveTransaction(batch, transaction);
+            const pendingOutputs = this.storageService.saveTransaction(
+                batch,
+                txData,
+            );
+            return { pendingOutputs, txData };
         }
-        return new Map();
+        return { pendingOutputs: new Map(), txData: null };
     }
 
     public deriveOutputsAndComputeScanTweak(

--- a/src/silent-blocks/silent-block-encoder.ts
+++ b/src/silent-blocks/silent-block-encoder.ts
@@ -1,0 +1,34 @@
+import { TransactionData } from '@/storage/interfaces';
+import { SILENT_PAYMENT_BLOCK_TYPE } from '@/common/constants';
+import { encodeVarInt, varIntSize } from '@/common/common';
+
+export function getSilentBlockLength(transactions: TransactionData[]): number {
+    let length = 1 + varIntSize(transactions.length);
+    for (const tx of transactions) {
+        length += 65 + varIntSize(tx.outputs.length) + tx.outputs.length * 44;
+    }
+    return length;
+}
+
+export function encodeSilentBlock(transactions: TransactionData[]): Buffer {
+    const block = Buffer.alloc(getSilentBlockLength(transactions));
+    let cursor = 0;
+
+    cursor = block.writeUInt8(SILENT_PAYMENT_BLOCK_TYPE, cursor);
+    cursor = encodeVarInt(transactions.length, block, cursor);
+
+    for (const tx of transactions) {
+        cursor += block.write(tx.id, cursor, 32, 'hex');
+        cursor = encodeVarInt(tx.outputs.length, block, cursor);
+
+        for (const output of tx.outputs) {
+            cursor = block.writeBigUInt64BE(BigInt(output.value), cursor);
+            cursor += block.write(output.pubKey, cursor, 32, 'hex');
+            cursor = block.writeUInt32BE(output.vout, cursor);
+        }
+
+        cursor += block.write(tx.scanTweak, cursor, 33, 'hex');
+    }
+
+    return block;
+}

--- a/src/silent-blocks/silent-block-encoder.ts
+++ b/src/silent-blocks/silent-block-encoder.ts
@@ -11,13 +11,17 @@ export function getSilentBlockLength(transactions: TransactionData[]): number {
 }
 
 export function encodeSilentBlock(transactions: TransactionData[]): Buffer {
-    const block = Buffer.alloc(getSilentBlockLength(transactions));
+    // Producers disagree on order; the bytes are cached immutable, so they can't.
+    const ordered = [...transactions].sort((a, b) =>
+        a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+    );
+    const block = Buffer.alloc(getSilentBlockLength(ordered));
     let cursor = 0;
 
     cursor = block.writeUInt8(SILENT_PAYMENT_BLOCK_TYPE, cursor);
-    cursor = encodeVarInt(transactions.length, block, cursor);
+    cursor = encodeVarInt(ordered.length, block, cursor);
 
-    for (const tx of transactions) {
+    for (const tx of ordered) {
         cursor += block.write(tx.id, cursor, 32, 'hex');
         cursor = encodeVarInt(tx.outputs.length, block, cursor);
 

--- a/src/silent-blocks/silent-blocks.controller.spec.ts
+++ b/src/silent-blocks/silent-blocks.controller.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CacheModule } from '@nestjs/cache-manager';
-import { CacheInterceptor } from '@nestjs/cache-manager';
+import { CacheInterceptor, CacheModule } from '@nestjs/cache-manager';
 import { SilentBlocksController } from '@/silent-blocks/silent-blocks.controller';
 import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
 import { THROTTLER_SKIP } from '@nestjs/throttler/dist/throttler.constants';
@@ -28,12 +27,12 @@ describe('SilentBlocksController', () => {
         controller = module.get<SilentBlocksController>(SilentBlocksController);
     });
 
-    it('should skip throttling on the range endpoint', () => {
+    it('should throttle the range endpoint', () => {
         const metadata = Reflect.getMetadata(
             THROTTLER_SKIP + 'default',
             controller.getSilentBlocksRange,
         );
-        expect(metadata).toBe(true);
+        expect(metadata).toBeUndefined();
     });
 
     it('should NOT have CacheInterceptor on getSilentBlockByHeight', () => {

--- a/src/silent-blocks/silent-blocks.controller.spec.ts
+++ b/src/silent-blocks/silent-blocks.controller.spec.ts
@@ -16,7 +16,6 @@ describe('SilentBlocksController', () => {
                 {
                     provide: SilentBlocksService,
                     useValue: {
-                        getSilentBlocksRange: jest.fn(),
                         streamSilentBlocksRange: jest.fn(),
                         getSilentBlockByHeight: jest.fn(),
                         getSilentBlockByHash: jest.fn(),

--- a/src/silent-blocks/silent-blocks.controller.spec.ts
+++ b/src/silent-blocks/silent-blocks.controller.spec.ts
@@ -3,6 +3,9 @@ import { CacheInterceptor, CacheModule } from '@nestjs/cache-manager';
 import { SilentBlocksController } from '@/silent-blocks/silent-blocks.controller';
 import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
 import { THROTTLER_SKIP } from '@nestjs/throttler/dist/throttler.constants';
+import { INestApplication } from '@nestjs/common';
+import { silentBlockSpanRange } from '@/storage/key-encoding';
+import * as request from 'supertest';
 
 describe('SilentBlocksController', () => {
     let controller: SilentBlocksController;
@@ -57,5 +60,106 @@ describe('SilentBlocksController', () => {
                 i === CacheInterceptor || i?.name === 'CacheInterceptor',
         );
         expect(hasCacheInterceptor).toBe(false);
+    });
+});
+
+describe('SilentBlocksController height bounds and streaming', () => {
+    let app: INestApplication;
+    let service: {
+        getLatestIndexedBlockHeight: jest.Mock;
+        streamSilentBlocksRange: jest.Mock;
+        getSilentBlockByHeight: jest.Mock;
+        getSilentBlockByHash: jest.Mock;
+    };
+
+    beforeEach(async () => {
+        service = {
+            getLatestIndexedBlockHeight: jest.fn().mockResolvedValue(1000),
+            // Exercise the real key encoder: an out-of-uint32 height throws
+            // from writeUInt32BE, which is what used to surface as a 500.
+            streamSilentBlocksRange: jest.fn(async function* (
+                from: number,
+                to: number,
+            ) {
+                silentBlockSpanRange(from, to);
+                for (let h = from; h <= to; h++) {
+                    const frame = Buffer.alloc(9);
+                    frame.writeUInt32BE(h, 0);
+                    frame.writeUInt32BE(1, 4);
+                    yield frame;
+                }
+            }),
+            getSilentBlockByHeight: jest
+                .fn()
+                .mockResolvedValue(Buffer.alloc(2)),
+            getSilentBlockByHash: jest.fn().mockResolvedValue(Buffer.alloc(2)),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            imports: [CacheModule.register()],
+            controllers: [SilentBlocksController],
+            providers: [{ provide: SilentBlocksService, useValue: service }],
+        }).compile();
+
+        app = module.createNestApplication();
+        await app.init();
+    });
+
+    afterEach(async () => {
+        await app.close();
+    });
+
+    it.each([
+        ['startHeight=5000000000&endHeight=5000000000', 'above uint32'],
+        [
+            'startHeight=4294967295&endHeight=4294967295',
+            'endHeight + 1 overflow',
+        ],
+    ])('rejects an out-of-range /range (%s) with 400, not 500', async (qs) => {
+        const res = await request(app.getHttpServer()).get(
+            `/silent-block/range?${qs}`,
+        );
+        expect(res.status).toBe(400);
+    });
+
+    it('rejects a negative height with 400, not 500', async () => {
+        const res = await request(app.getHttpServer()).get(
+            '/silent-block/height/-1',
+        );
+        expect(res.status).toBe(400);
+        expect(service.getSilentBlockByHeight).not.toHaveBeenCalled();
+    });
+
+    it('clamps endHeight to the indexed tip', async () => {
+        service.getLatestIndexedBlockHeight.mockResolvedValue(1005);
+        await request(app.getHttpServer()).get(
+            '/silent-block/range?startHeight=1000&endHeight=1100',
+        );
+        expect(service.streamSilentBlocksRange).toHaveBeenCalledWith(
+            1000,
+            1005,
+            false,
+        );
+    });
+
+    it('does not end a truncated range cleanly when the stream throws', async () => {
+        service.streamSilentBlocksRange.mockImplementation(
+            // eslint-disable-next-line require-yield
+            async function* () {
+                yield Buffer.alloc(9);
+                throw new Error('lmdb read failed');
+            },
+        );
+
+        const outcome = await request(app.getHttpServer())
+            .get('/silent-block/range?startHeight=0&endHeight=10')
+            .then(
+                (res) => ({ ok: true as const, status: res.status }),
+                (err) => ({ ok: false as const, message: String(err.message) }),
+            );
+
+        // The socket is destroyed rather than end()ed, so the client sees a
+        // transport error instead of a complete-looking short body.
+        expect(outcome.ok).toBe(false);
     });
 });

--- a/src/silent-blocks/silent-blocks.controller.spec.ts
+++ b/src/silent-blocks/silent-blocks.controller.spec.ts
@@ -130,6 +130,27 @@ describe('SilentBlocksController height bounds and streaming', () => {
         expect(service.getSilentBlockByHeight).not.toHaveBeenCalled();
     });
 
+    it('404s a height above the indexed tip instead of serving an empty block', async () => {
+        // An unindexed height encodes to the same 2 bytes as an empty block,
+        // so serving it reads as "no payments here".
+        const res = await request(app.getHttpServer()).get(
+            '/silent-block/height/1001',
+        );
+        expect(res.status).toBe(404);
+        expect(service.getSilentBlockByHeight).not.toHaveBeenCalled();
+    });
+
+    it('serves a height at the indexed tip', async () => {
+        const res = await request(app.getHttpServer()).get(
+            '/silent-block/height/1000',
+        );
+        expect(res.status).toBe(200);
+        expect(service.getSilentBlockByHeight).toHaveBeenCalledWith(
+            1000,
+            false,
+        );
+    });
+
     it('clamps endHeight to the indexed tip', async () => {
         service.getLatestIndexedBlockHeight.mockResolvedValue(1005);
         await request(app.getHttpServer()).get(

--- a/src/silent-blocks/silent-blocks.controller.spec.ts
+++ b/src/silent-blocks/silent-blocks.controller.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CacheModule } from '@nestjs/cache-manager';
+import { CacheInterceptor } from '@nestjs/cache-manager';
+import { SilentBlocksController } from '@/silent-blocks/silent-blocks.controller';
+import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
+import { THROTTLER_SKIP } from '@nestjs/throttler/dist/throttler.constants';
+
+describe('SilentBlocksController', () => {
+    let controller: SilentBlocksController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            imports: [CacheModule.register()],
+            controllers: [SilentBlocksController],
+            providers: [
+                {
+                    provide: SilentBlocksService,
+                    useValue: {
+                        getSilentBlocksRange: jest.fn(),
+                        getSilentBlockByHeight: jest.fn(),
+                        getSilentBlockByHash: jest.fn(),
+                        getLatestIndexedBlockHeight: jest.fn(),
+                    },
+                },
+            ],
+        }).compile();
+
+        controller = module.get<SilentBlocksController>(SilentBlocksController);
+    });
+
+    it('should skip throttling on the range endpoint', () => {
+        const metadata = Reflect.getMetadata(
+            THROTTLER_SKIP + 'default',
+            controller.getSilentBlocksRange,
+        );
+        expect(metadata).toBe(true);
+    });
+
+    it('should NOT have CacheInterceptor on getSilentBlockByHeight', () => {
+        const interceptors = Reflect.getMetadata(
+            '__interceptors__',
+            controller.getSilentBlockByHeight,
+        );
+        const hasCacheInterceptor = (interceptors ?? []).some(
+            (i: any) =>
+                i === CacheInterceptor || i?.name === 'CacheInterceptor',
+        );
+        expect(hasCacheInterceptor).toBe(false);
+    });
+
+    it('should NOT have CacheInterceptor on getSilentBlockByHash', () => {
+        const interceptors = Reflect.getMetadata(
+            '__interceptors__',
+            controller.getSilentBlockByHash,
+        );
+        const hasCacheInterceptor = (interceptors ?? []).some(
+            (i: any) =>
+                i === CacheInterceptor || i?.name === 'CacheInterceptor',
+        );
+        expect(hasCacheInterceptor).toBe(false);
+    });
+});

--- a/src/silent-blocks/silent-blocks.controller.spec.ts
+++ b/src/silent-blocks/silent-blocks.controller.spec.ts
@@ -17,6 +17,7 @@ describe('SilentBlocksController', () => {
                     provide: SilentBlocksService,
                     useValue: {
                         getSilentBlocksRange: jest.fn(),
+                        streamSilentBlocksRange: jest.fn(),
                         getSilentBlockByHeight: jest.fn(),
                         getSilentBlockByHash: jest.fn(),
                         getLatestIndexedBlockHeight: jest.fn(),

--- a/src/silent-blocks/silent-blocks.controller.ts
+++ b/src/silent-blocks/silent-blocks.controller.ts
@@ -1,6 +1,5 @@
 import { CacheInterceptor } from '@nestjs/cache-manager';
 import {
-    BadRequestException,
     Controller,
     Get,
     Param,
@@ -11,24 +10,20 @@ import {
     UseInterceptors,
 } from '@nestjs/common';
 import { Response } from 'express';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
 import { MAX_SILENT_BLOCK_RANGE } from '@/common/constants';
+import { assertHeight, assertHeightRange } from '@/common/common';
 
 const CACHE_CONFIRMATION_DEPTH = 6;
 
 const IMMUTABLE = 'public, max-age=31536000, immutable';
 const NO_STORE = 'no-store';
 
-const drained = (res: Response): Promise<void> =>
-    new Promise((resolve) => {
-        const done = () => {
-            res.off('drain', done);
-            res.off('close', done);
-            resolve();
-        };
-        res.once('drain', done);
-        res.once('close', done);
-    });
+// A client that stops reading must not pin the generator (and its LMDB reads)
+// forever. Mirrors STALL_TIMEOUT_MS on the WebSocket path.
+const STREAM_STALL_TIMEOUT_MS = 60_000;
 
 @Controller('silent-block')
 export class SilentBlocksController {
@@ -41,16 +36,20 @@ export class SilentBlocksController {
         @Query('filterSpent', new ParseBoolPipe({ optional: true }))
         filterSpent = false,
     ) {
+        assertHeight(blockHeight, 'height');
+
         const buffer = await this.silentBlocksService.getSilentBlockByHeight(
             blockHeight,
             filterSpent,
         );
 
-        const latestHeight =
-            await this.silentBlocksService.getLatestIndexedBlockHeight();
+        // filterSpent responses are always live, so don't pay for the tip
+        // lookup only to discard it.
         const cacheable =
             !filterSpent &&
-            blockHeight <= latestHeight - CACHE_CONFIRMATION_DEPTH;
+            blockHeight <=
+                (await this.silentBlocksService.getLatestIndexedBlockHeight()) -
+                    CACHE_CONFIRMATION_DEPTH;
 
         res.set({
             'Content-Type': 'application/octet-stream',
@@ -89,41 +88,46 @@ export class SilentBlocksController {
         @Query('filterSpent', new ParseBoolPipe({ optional: true }))
         filterSpent = false,
     ) {
-        if (startHeight < 0) {
-            throw new BadRequestException('startHeight must be >= 0');
-        }
-        if (endHeight < startHeight) {
-            throw new BadRequestException('endHeight must be >= startHeight');
-        }
-        if (endHeight - startHeight + 1 > MAX_SILENT_BLOCK_RANGE) {
-            throw new BadRequestException(
-                `Range exceeds maximum of ${MAX_SILENT_BLOCK_RANGE} blocks`,
-            );
-        }
+        assertHeightRange(startHeight, endHeight, MAX_SILENT_BLOCK_RANGE);
 
         const latestHeight =
             await this.silentBlocksService.getLatestIndexedBlockHeight();
 
+        // Empty heights are omitted from the stream, so an unindexed height is
+        // byte-identical to an empty one. Clamp to the tip (as the WebSocket
+        // path does) so we never present "not indexed yet" as "no payments".
+        const lastHeight = Math.min(endHeight, latestHeight);
+
         // filterSpent responses are always live — never cache them
         const isDeepRange =
             !filterSpent &&
-            endHeight <= latestHeight - CACHE_CONFIRMATION_DEPTH;
+            lastHeight <= latestHeight - CACHE_CONFIRMATION_DEPTH;
         res.set({
             'Content-Type': 'application/octet-stream',
             'Cache-Control': isDeepRange ? IMMUTABLE : NO_STORE,
         });
 
-        for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
-            startHeight,
-            endHeight,
-            filterSpent,
-        )) {
-            if (res.closed || res.destroyed) return;
-            if (!res.write(frame)) {
-                await drained(res);
-            }
+        res.setTimeout(STREAM_STALL_TIMEOUT_MS, () => res.destroy());
+
+        try {
+            await pipeline(
+                Readable.from(
+                    this.silentBlocksService.streamSilentBlocksRange(
+                        startHeight,
+                        lastHeight,
+                        filterSpent,
+                    ),
+                    { objectMode: false },
+                ),
+                res,
+            );
+        } catch {
+            // Headers are already out, so letting Nest's filter end() the
+            // response would present a truncated range as a complete one — and
+            // a deep range is cached immutable for a year. Break the connection
+            // instead so the client retries.
+            res.destroy();
         }
-        res.end();
     }
 
     @Get('latest-height')

--- a/src/silent-blocks/silent-blocks.controller.ts
+++ b/src/silent-blocks/silent-blocks.controller.ts
@@ -10,6 +10,7 @@ import {
     Res,
     UseInterceptors,
 } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import { Response } from 'express';
 import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
 import { MAX_SILENT_BLOCK_RANGE } from '@/common/constants';
@@ -19,7 +20,6 @@ export class SilentBlocksController {
     constructor(private readonly silentBlocksService: SilentBlocksService) {}
 
     @Get('height/:height')
-    @UseInterceptors(CacheInterceptor)
     async getSilentBlockByHeight(
         @Param('height') blockHeight: number,
         @Res() res: Response,
@@ -34,12 +34,14 @@ export class SilentBlocksController {
         res.set({
             'Content-Type': 'application/octet-stream',
             'Content-Length': buffer.length,
+            'Cache-Control': filterSpent
+                ? 'no-store'
+                : 'public, max-age=31536000, immutable',
         });
         res.send(buffer);
     }
 
     @Get('hash/:hash')
-    @UseInterceptors(CacheInterceptor)
     async getSilentBlockByHash(
         @Param('hash') blockHash: string,
         @Res() res: Response,
@@ -54,10 +56,14 @@ export class SilentBlocksController {
         res.set({
             'Content-Type': 'application/octet-stream',
             'Content-Length': buffer.length,
+            'Cache-Control': filterSpent
+                ? 'no-store'
+                : 'public, max-age=31536000, immutable',
         });
         res.send(buffer);
     }
 
+    @SkipThrottle()
     @Get('range')
     async getSilentBlocksRange(
         @Query('startHeight', ParseIntPipe) startHeight: number,

--- a/src/silent-blocks/silent-blocks.controller.ts
+++ b/src/silent-blocks/silent-blocks.controller.ts
@@ -69,6 +69,8 @@ export class SilentBlocksController {
         @Query('startHeight', ParseIntPipe) startHeight: number,
         @Query('endHeight', ParseIntPipe) endHeight: number,
         @Res() res: Response,
+        @Query('filterSpent', new ParseBoolPipe({ optional: true }))
+        filterSpent = false,
     ) {
         if (endHeight < startHeight) {
             throw new BadRequestException('endHeight must be >= startHeight');
@@ -82,7 +84,9 @@ export class SilentBlocksController {
         const latestHeight =
             await this.silentBlocksService.getLatestIndexedBlockHeight();
 
-        const isDeepRange = endHeight <= latestHeight - 6;
+        // filterSpent responses are always live — never cache them
+        const isDeepRange =
+            !filterSpent && endHeight <= latestHeight - 6;
         res.set({
             'Content-Type': 'application/octet-stream',
             'Transfer-Encoding': 'chunked',
@@ -94,6 +98,7 @@ export class SilentBlocksController {
         for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
             startHeight,
             endHeight,
+            filterSpent,
         )) {
             res.write(frame);
         }

--- a/src/silent-blocks/silent-blocks.controller.ts
+++ b/src/silent-blocks/silent-blocks.controller.ts
@@ -85,8 +85,7 @@ export class SilentBlocksController {
             await this.silentBlocksService.getLatestIndexedBlockHeight();
 
         // filterSpent responses are always live — never cache them
-        const isDeepRange =
-            !filterSpent && endHeight <= latestHeight - 6;
+        const isDeepRange = !filterSpent && endHeight <= latestHeight - 6;
         res.set({
             'Content-Type': 'application/octet-stream',
             'Transfer-Encoding': 'chunked',

--- a/src/silent-blocks/silent-blocks.controller.ts
+++ b/src/silent-blocks/silent-blocks.controller.ts
@@ -1,15 +1,18 @@
 import { CacheInterceptor } from '@nestjs/cache-manager';
 import {
+    BadRequestException,
     Controller,
     Get,
     Param,
     ParseBoolPipe,
+    ParseIntPipe,
     Query,
     Res,
     UseInterceptors,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
+import { MAX_SILENT_BLOCK_RANGE } from '@/common/constants';
 
 @Controller('silent-block')
 export class SilentBlocksController {
@@ -51,6 +54,40 @@ export class SilentBlocksController {
         res.set({
             'Content-Type': 'application/octet-stream',
             'Content-Length': buffer.length,
+        });
+        res.send(buffer);
+    }
+
+    @Get('range')
+    async getSilentBlocksRange(
+        @Query('startHeight', ParseIntPipe) startHeight: number,
+        @Query('endHeight', ParseIntPipe) endHeight: number,
+        @Res() res: Response,
+    ) {
+        if (endHeight < startHeight) {
+            throw new BadRequestException('endHeight must be >= startHeight');
+        }
+        if (endHeight - startHeight + 1 > MAX_SILENT_BLOCK_RANGE) {
+            throw new BadRequestException(
+                `Range exceeds maximum of ${MAX_SILENT_BLOCK_RANGE} blocks`,
+            );
+        }
+
+        const latestHeight =
+            await this.silentBlocksService.getLatestIndexedBlockHeight();
+
+        const buffer = await this.silentBlocksService.getSilentBlocksRange(
+            startHeight,
+            endHeight,
+        );
+
+        const isDeepRange = endHeight <= latestHeight - 6;
+        res.set({
+            'Content-Type': 'application/octet-stream',
+            'Content-Length': buffer.length,
+            'Cache-Control': isDeepRange
+                ? 'public, max-age=31536000, immutable'
+                : 'no-store',
         });
         res.send(buffer);
     }

--- a/src/silent-blocks/silent-blocks.controller.ts
+++ b/src/silent-blocks/silent-blocks.controller.ts
@@ -82,20 +82,22 @@ export class SilentBlocksController {
         const latestHeight =
             await this.silentBlocksService.getLatestIndexedBlockHeight();
 
-        const buffer = await this.silentBlocksService.getSilentBlocksRange(
-            startHeight,
-            endHeight,
-        );
-
         const isDeepRange = endHeight <= latestHeight - 6;
         res.set({
             'Content-Type': 'application/octet-stream',
-            'Content-Length': buffer.length,
+            'Transfer-Encoding': 'chunked',
             'Cache-Control': isDeepRange
                 ? 'public, max-age=31536000, immutable'
                 : 'no-store',
         });
-        res.send(buffer);
+
+        for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
+            startHeight,
+            endHeight,
+        )) {
+            res.write(frame);
+        }
+        res.end();
     }
 
     @Get('latest-height')

--- a/src/silent-blocks/silent-blocks.controller.ts
+++ b/src/silent-blocks/silent-blocks.controller.ts
@@ -2,6 +2,7 @@ import { CacheInterceptor } from '@nestjs/cache-manager';
 import {
     Controller,
     Get,
+    NotFoundException,
     Param,
     ParseBoolPipe,
     ParseIntPipe,
@@ -38,18 +39,26 @@ export class SilentBlocksController {
     ) {
         assertHeight(blockHeight, 'height');
 
+        const latestHeight =
+            await this.silentBlocksService.getLatestIndexedBlockHeight();
+
+        // An unindexed height encodes to the same 2 bytes as a genuinely empty
+        // block, so serving it would tell the client "no payments here" for a
+        // block we haven't seen. /range clamps for the same reason.
+        if (blockHeight > latestHeight) {
+            throw new NotFoundException(
+                `height ${blockHeight} is not indexed yet (tip ${latestHeight})`,
+            );
+        }
+
         const buffer = await this.silentBlocksService.getSilentBlockByHeight(
             blockHeight,
             filterSpent,
         );
 
-        // filterSpent responses are always live, so don't pay for the tip
-        // lookup only to discard it.
         const cacheable =
             !filterSpent &&
-            blockHeight <=
-                (await this.silentBlocksService.getLatestIndexedBlockHeight()) -
-                    CACHE_CONFIRMATION_DEPTH;
+            blockHeight <= latestHeight - CACHE_CONFIRMATION_DEPTH;
 
         res.set({
             'Content-Type': 'application/octet-stream',

--- a/src/silent-blocks/silent-blocks.controller.ts
+++ b/src/silent-blocks/silent-blocks.controller.ts
@@ -10,10 +10,25 @@ import {
     Res,
     UseInterceptors,
 } from '@nestjs/common';
-import { SkipThrottle } from '@nestjs/throttler';
 import { Response } from 'express';
 import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
 import { MAX_SILENT_BLOCK_RANGE } from '@/common/constants';
+
+const CACHE_CONFIRMATION_DEPTH = 6;
+
+const IMMUTABLE = 'public, max-age=31536000, immutable';
+const NO_STORE = 'no-store';
+
+const drained = (res: Response): Promise<void> =>
+    new Promise((resolve) => {
+        const done = () => {
+            res.off('drain', done);
+            res.off('close', done);
+            resolve();
+        };
+        res.once('drain', done);
+        res.once('close', done);
+    });
 
 @Controller('silent-block')
 export class SilentBlocksController {
@@ -21,7 +36,7 @@ export class SilentBlocksController {
 
     @Get('height/:height')
     async getSilentBlockByHeight(
-        @Param('height') blockHeight: number,
+        @Param('height', ParseIntPipe) blockHeight: number,
         @Res() res: Response,
         @Query('filterSpent', new ParseBoolPipe({ optional: true }))
         filterSpent = false,
@@ -31,12 +46,16 @@ export class SilentBlocksController {
             filterSpent,
         );
 
+        const latestHeight =
+            await this.silentBlocksService.getLatestIndexedBlockHeight();
+        const cacheable =
+            !filterSpent &&
+            blockHeight <= latestHeight - CACHE_CONFIRMATION_DEPTH;
+
         res.set({
             'Content-Type': 'application/octet-stream',
             'Content-Length': buffer.length,
-            'Cache-Control': filterSpent
-                ? 'no-store'
-                : 'public, max-age=31536000, immutable',
+            'Cache-Control': cacheable ? IMMUTABLE : NO_STORE,
         });
         res.send(buffer);
     }
@@ -56,14 +75,12 @@ export class SilentBlocksController {
         res.set({
             'Content-Type': 'application/octet-stream',
             'Content-Length': buffer.length,
-            'Cache-Control': filterSpent
-                ? 'no-store'
-                : 'public, max-age=31536000, immutable',
+            // Depth is unknowable from a hash, so bound staleness instead.
+            'Cache-Control': filterSpent ? NO_STORE : 'public, max-age=60',
         });
         res.send(buffer);
     }
 
-    @SkipThrottle()
     @Get('range')
     async getSilentBlocksRange(
         @Query('startHeight', ParseIntPipe) startHeight: number,
@@ -72,6 +89,9 @@ export class SilentBlocksController {
         @Query('filterSpent', new ParseBoolPipe({ optional: true }))
         filterSpent = false,
     ) {
+        if (startHeight < 0) {
+            throw new BadRequestException('startHeight must be >= 0');
+        }
         if (endHeight < startHeight) {
             throw new BadRequestException('endHeight must be >= startHeight');
         }
@@ -85,13 +105,12 @@ export class SilentBlocksController {
             await this.silentBlocksService.getLatestIndexedBlockHeight();
 
         // filterSpent responses are always live — never cache them
-        const isDeepRange = !filterSpent && endHeight <= latestHeight - 6;
+        const isDeepRange =
+            !filterSpent &&
+            endHeight <= latestHeight - CACHE_CONFIRMATION_DEPTH;
         res.set({
             'Content-Type': 'application/octet-stream',
-            'Transfer-Encoding': 'chunked',
-            'Cache-Control': isDeepRange
-                ? 'public, max-age=31536000, immutable'
-                : 'no-store',
+            'Cache-Control': isDeepRange ? IMMUTABLE : NO_STORE,
         });
 
         for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
@@ -99,7 +118,10 @@ export class SilentBlocksController {
             endHeight,
             filterSpent,
         )) {
-            res.write(frame);
+            if (res.closed || res.destroyed) return;
+            if (!res.write(frame)) {
+                await drained(res);
+            }
         }
         res.end();
     }

--- a/src/silent-blocks/silent-blocks.gateway.spec.ts
+++ b/src/silent-blocks/silent-blocks.gateway.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { WebSocket } from 'ws';
 import { SilentBlocksGateway } from '@/silent-blocks/silent-blocks.gateway';
 import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
@@ -98,6 +99,34 @@ describe('SilentBlocksGateway sync stream', () => {
         const { frames, controls } = classify(client.send as jest.Mock);
         expect(frames).toHaveLength(0);
         expect(controls[0].event).toBe('error');
+    });
+
+    it('terminates a client that never drains, without acking', async () => {
+        jest.useFakeTimers();
+        jest.spyOn(Logger.prototype, 'warn').mockImplementation(
+            () => undefined,
+        );
+        try {
+            const gateway = new SilentBlocksGateway(serviceStub(1000));
+            const client = fakeClient({
+                bufferedAmount: 8 * 1024 * 1024, // pinned above MAX_BUFFERED_BYTES
+            }) as any;
+            // Mirror ws: terminate() leaves the socket no longer OPEN.
+            client.terminate = jest.fn(() => {
+                client.readyState = WebSocket.CLOSED;
+            });
+
+            const done = gateway.handleSync(client, { from: 100, to: 200 });
+            await jest.advanceTimersByTimeAsync(61_000);
+            await done;
+
+            expect(client.terminate).toHaveBeenCalled();
+            // Stalled before the first send, so no frames and no `synced` ack.
+            expect(client.send).not.toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+            jest.restoreAllMocks();
+        }
     });
 
     it('stops sending once the socket is no longer open', async () => {

--- a/src/silent-blocks/silent-blocks.gateway.spec.ts
+++ b/src/silent-blocks/silent-blocks.gateway.spec.ts
@@ -159,6 +159,50 @@ describe('SilentBlocksGateway sync stream', () => {
         expect(controls.filter((c) => c.event === 'synced')).toHaveLength(1);
     });
 
+    it('streams blocks indexed while the sync was running', async () => {
+        // broadcastSilentBlock skips a client in `syncing`, and those heights
+        // are past the `to` fixed at sync start — without a catch-up pass they
+        // are dropped with no signal to the client.
+        const service = serviceStub(102);
+        (service.getLatestIndexedBlockHeight as jest.Mock)
+            .mockResolvedValueOnce(102) // tip at sync start
+            .mockResolvedValue(104); // two blocks landed mid-stream
+        const gateway = new SilentBlocksGateway(service);
+        const client = fakeClient();
+
+        await gateway.handleSync(client, { from: 100 });
+
+        const { frames, controls } = classify(client.send as jest.Mock);
+        expect(frames.map((f) => f.readUInt32BE(0))).toEqual([
+            100, 101, 102, 103, 104,
+        ]);
+        expect(controls[0]).toEqual({
+            event: 'synced',
+            data: { from: 100, to: 104, tip: 104, count: 5 },
+        });
+    });
+
+    it('acks with `tip` above `to` when the tip never settles', async () => {
+        // A tip advancing every pass (regtest/IBD) must not pin the socket.
+        // Bail after the round cap and let the ack tell the client it's behind
+        // — `to` must still be a height we actually streamed.
+        let tip = 100;
+        const service = serviceStub(100);
+        (service.getLatestIndexedBlockHeight as jest.Mock).mockImplementation(
+            async () => ++tip,
+        );
+        const gateway = new SilentBlocksGateway(service);
+        const client = fakeClient();
+
+        await gateway.handleSync(client, { from: 100 });
+
+        const { frames, controls } = classify(client.send as jest.Mock);
+        const heights = frames.map((f) => f.readUInt32BE(0));
+        expect(controls[0].event).toBe('synced');
+        expect(controls[0].data.tip).toBeGreaterThan(controls[0].data.to);
+        expect(heights[heights.length - 1]).toBe(controls[0].data.to);
+    });
+
     it.each([[null], [''], [[]], [false], ['12']])(
         'rejects a non-integer `from` (%p) instead of coercing it to 0',
         async (from) => {

--- a/src/silent-blocks/silent-blocks.gateway.spec.ts
+++ b/src/silent-blocks/silent-blocks.gateway.spec.ts
@@ -1,0 +1,112 @@
+import { WebSocket } from 'ws';
+import { SilentBlocksGateway } from '@/silent-blocks/silent-blocks.gateway';
+import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
+
+/** Build a fake `ws` client whose send/readyState/bufferedAmount we can drive. */
+function fakeClient(overrides: Partial<WebSocket> = {}) {
+    return {
+        readyState: WebSocket.OPEN,
+        bufferedAmount: 0,
+        send: jest.fn(),
+        ...overrides,
+    } as unknown as WebSocket;
+}
+
+/** A service stub whose stream yields one 8-byte+ frame per height in [from,to]. */
+function serviceStub(tip: number): SilentBlocksService {
+    return {
+        getLatestIndexedBlockHeight: jest.fn().mockResolvedValue(tip),
+        async *streamSilentBlocksRange(from: number, to: number) {
+            for (let h = from; h <= to; h++) {
+                const frame = Buffer.alloc(9);
+                frame.writeUInt32BE(h, 0);
+                frame.writeUInt32BE(1, 4);
+                yield frame;
+            }
+        },
+    } as unknown as SilentBlocksService;
+}
+
+/** Split a client's send() calls into binary frames and parsed text controls. */
+function classify(send: jest.Mock) {
+    const frames: Buffer[] = [];
+    const controls: any[] = [];
+    for (const [payload] of send.mock.calls) {
+        if (typeof payload === 'string') controls.push(JSON.parse(payload));
+        else frames.push(payload as Buffer);
+    }
+    return { frames, controls };
+}
+
+describe('SilentBlocksGateway sync stream', () => {
+    it('streams one frame per height then a synced control', async () => {
+        const gateway = new SilentBlocksGateway(serviceStub(1000));
+        const client = fakeClient();
+
+        await gateway.handleSync(client, {
+            from: 100,
+            to: 104,
+            filterSpent: true,
+        });
+
+        const { frames, controls } = classify(client.send as jest.Mock);
+        expect(frames).toHaveLength(5); // heights 100..104
+        expect(frames[0].readUInt32BE(0)).toBe(100);
+        expect(frames[4].readUInt32BE(0)).toBe(104);
+        expect(controls).toEqual([
+            {
+                event: 'synced',
+                data: { from: 100, to: 104, tip: 1000, count: 5 },
+            },
+        ]);
+    });
+
+    it('clamps `to` to the current tip', async () => {
+        const gateway = new SilentBlocksGateway(serviceStub(102));
+        const client = fakeClient();
+
+        await gateway.handleSync(client, { from: 100, to: 999 });
+
+        const { frames, controls } = classify(client.send as jest.Mock);
+        expect(frames).toHaveLength(3); // 100..102 (clamped)
+        expect(controls[0]).toEqual({
+            event: 'synced',
+            data: { from: 100, to: 102, tip: 102, count: 3 },
+        });
+    });
+
+    it('acks with count 0 when the client is already at tip', async () => {
+        const gateway = new SilentBlocksGateway(serviceStub(50));
+        const client = fakeClient();
+
+        await gateway.handleSync(client, { from: 100 });
+
+        const { frames, controls } = classify(client.send as jest.Mock);
+        expect(frames).toHaveLength(0);
+        expect(controls[0]).toEqual({
+            event: 'synced',
+            data: { from: 100, to: 50, tip: 50, count: 0 },
+        });
+    });
+
+    it('rejects a missing/invalid `from`', async () => {
+        const gateway = new SilentBlocksGateway(serviceStub(1000));
+        const client = fakeClient();
+
+        await gateway.handleSync(client, {} as any);
+
+        const { frames, controls } = classify(client.send as jest.Mock);
+        expect(frames).toHaveLength(0);
+        expect(controls[0].event).toBe('error');
+    });
+
+    it('stops sending once the socket is no longer open', async () => {
+        const gateway = new SilentBlocksGateway(serviceStub(1000));
+        const client = fakeClient({ readyState: WebSocket.CLOSING });
+
+        await gateway.handleSync(client, { from: 100, to: 200 });
+
+        // Closed before first send: no frames, no synced control.
+        expect(client.send as jest.Mock).not.toHaveBeenCalled();
+    });
+});

--- a/src/silent-blocks/silent-blocks.gateway.spec.ts
+++ b/src/silent-blocks/silent-blocks.gateway.spec.ts
@@ -138,4 +138,64 @@ describe('SilentBlocksGateway sync stream', () => {
         // Closed before first send: no frames, no synced control.
         expect(client.send as jest.Mock).not.toHaveBeenCalled();
     });
+
+    it('rejects a second concurrent sync on the same socket', async () => {
+        // The ws adapter dispatches with mergeMap, so nothing serialises
+        // handlers per socket; without a guard the first to finish clears
+        // `syncing` and re-admits unframed broadcasts into the second stream.
+        const gateway = new SilentBlocksGateway(serviceStub(1000));
+        const client = fakeClient();
+
+        const first = gateway.handleSync(client, { from: 100, to: 300 });
+        const second = gateway.handleSync(client, { from: 100, to: 300 });
+        await Promise.all([first, second]);
+
+        const { controls } = classify(client.send as jest.Mock);
+        expect(
+            controls.filter((c) => c.event === 'error').map((c) => c.data),
+        ).toEqual([
+            { message: 'a sync is already in progress on this socket' },
+        ]);
+        expect(controls.filter((c) => c.event === 'synced')).toHaveLength(1);
+    });
+
+    it.each([[null], [''], [[]], [false], ['12']])(
+        'rejects a non-integer `from` (%p) instead of coercing it to 0',
+        async (from) => {
+            const gateway = new SilentBlocksGateway(serviceStub(1000));
+            const client = fakeClient();
+
+            await gateway.handleSync(client, { from } as any);
+
+            const { frames, controls } = classify(client.send as jest.Mock);
+            expect(frames).toHaveLength(0);
+            expect(controls[0].event).toBe('error');
+        },
+    );
+
+    it('honours filterSpent sent as the string "false"', async () => {
+        const service = serviceStub(1000);
+        const spy = jest.spyOn(service, 'streamSilentBlocksRange');
+        const gateway = new SilentBlocksGateway(service);
+
+        await gateway.handleSync(fakeClient(), {
+            from: 100,
+            to: 101,
+            filterSpent: 'false',
+        } as any);
+
+        expect(spy).toHaveBeenCalledWith(100, 101, false);
+    });
+
+    it('releases the sync slot so a later sync can run', async () => {
+        const gateway = new SilentBlocksGateway(serviceStub(1000));
+        const client = fakeClient();
+
+        await gateway.handleSync(client, { from: 100, to: 101 });
+        await gateway.handleSync(client, { from: 102, to: 103 });
+
+        const { controls } = classify(client.send as jest.Mock);
+        expect(controls.filter((c) => c.event === 'synced')).toHaveLength(2);
+        expect(controls.some((c) => c.event === 'error')).toBe(false);
+    });
 });

--- a/src/silent-blocks/silent-blocks.gateway.ts
+++ b/src/silent-blocks/silent-blocks.gateway.ts
@@ -109,6 +109,11 @@ export class SilentBlocksGateway
         }
     }
 
+    @SubscribeMessage('ping')
+    handlePing(@ConnectedSocket() client: WebSocket): void {
+        this.sendControl(client, 'pong', null);
+    }
+
     broadcastSilentBlock(silentBlock: Buffer) {
         for (const client of this.server.clients) {
             if (client.readyState === WebSocket.OPEN) {

--- a/src/silent-blocks/silent-blocks.gateway.ts
+++ b/src/silent-blocks/silent-blocks.gateway.ts
@@ -70,9 +70,23 @@ export class SilentBlocksGateway
         @ConnectedSocket() client: WebSocket,
         @MessageBody() data: SyncRequest,
     ): Promise<void> {
+        // The ws adapter dispatches messages with `mergeMap`, so nothing
+        // serialises handlers per socket. Two overlapping syncs would interleave
+        // frames and the first to finish would clear `syncing`, re-admitting
+        // unframed broadcasts into the other's stream.
+        if (this.syncing.has(client)) {
+            this.sendControl(client, 'error', {
+                message: 'a sync is already in progress on this socket',
+            });
+            return;
+        }
+        this.syncing.add(client);
+
         try {
-            const from = Math.floor(Number(data?.from));
-            if (!Number.isFinite(from) || from < 0) {
+            // Number() coerces null/''/[]/false to 0, which would silently turn
+            // a junk cursor into a full sync from genesis.
+            const from = data?.from;
+            if (!Number.isInteger(from) || from < 0) {
                 this.sendControl(client, 'error', {
                     message: 'sync requires a non-negative integer `from`',
                 });
@@ -81,16 +95,15 @@ export class SilentBlocksGateway
 
             const tip =
                 await this.silentBlocksService.getLatestIndexedBlockHeight();
-            const requestedTo =
-                data?.to != null ? Math.floor(Number(data.to)) : tip;
-            if (!Number.isFinite(requestedTo)) {
+            if (data?.to != null && !Number.isInteger(data.to)) {
                 this.sendControl(client, 'error', {
                     message: '`to` must be an integer',
                 });
                 return;
             }
-            const to = Math.min(requestedTo, tip);
-            const filterSpent = data?.filterSpent ?? true;
+            const to = Math.min(data?.to ?? tip, tip);
+            // `?? true` alone would keep the truthy string "false".
+            const filterSpent = String(data?.filterSpent ?? true) !== 'false';
 
             if (to < from) {
                 // Nothing to send (client already at/above tip) — still ack.
@@ -99,21 +112,16 @@ export class SilentBlocksGateway
             }
 
             let count = 0;
-            this.syncing.add(client);
-            try {
-                for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
-                    from,
-                    to,
-                    filterSpent,
-                )) {
-                    if (client.readyState !== WebSocket.OPEN) return; // client gone
-                    await this.awaitDrain(client);
-                    if (client.readyState !== WebSocket.OPEN) return;
-                    client.send(frame, { binary: true });
-                    count++;
-                }
-            } finally {
-                this.syncing.delete(client);
+            for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
+                from,
+                to,
+                filterSpent,
+            )) {
+                if (client.readyState !== WebSocket.OPEN) return; // client gone
+                await this.awaitDrain(client);
+                if (client.readyState !== WebSocket.OPEN) return;
+                client.send(frame, { binary: true });
+                count++;
             }
 
             this.sendControl(client, 'synced', { from, to, tip, count });
@@ -126,6 +134,8 @@ export class SilentBlocksGateway
             this.sendControl(client, 'error', {
                 message: err instanceof Error ? err.message : 'sync failed',
             });
+        } finally {
+            this.syncing.delete(client);
         }
     }
 

--- a/src/silent-blocks/silent-blocks.gateway.ts
+++ b/src/silent-blocks/silent-blocks.gateway.ts
@@ -30,6 +30,9 @@ export class SilentBlocksGateway
 
     @WebSocketServer() server: Server;
 
+    // Clients mid-backfill: a bare tip broadcast would desync their frame parser.
+    private readonly syncing = new Set<WebSocket>();
+
     constructor(
         @Inject(forwardRef(() => SilentBlocksService))
         private readonly silentBlocksService: SilentBlocksService,
@@ -41,6 +44,7 @@ export class SilentBlocksGateway
     }
 
     handleDisconnect(client: WebSocket) {
+        this.syncing.delete(client);
         const remoteAddress = (client as any)._socket.remoteAddress;
         this.logger.debug(`Client disconnected: ${remoteAddress}`);
     }
@@ -74,6 +78,12 @@ export class SilentBlocksGateway
                 await this.silentBlocksService.getLatestIndexedBlockHeight();
             const requestedTo =
                 data?.to != null ? Math.floor(Number(data.to)) : tip;
+            if (!Number.isFinite(requestedTo)) {
+                this.sendControl(client, 'error', {
+                    message: '`to` must be an integer',
+                });
+                return;
+            }
             const to = Math.min(requestedTo, tip);
             const filterSpent = data?.filterSpent ?? true;
 
@@ -84,16 +94,21 @@ export class SilentBlocksGateway
             }
 
             let count = 0;
-            for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
-                from,
-                to,
-                filterSpent,
-            )) {
-                if (client.readyState !== WebSocket.OPEN) return; // client gone
-                await this.awaitDrain(client);
-                if (client.readyState !== WebSocket.OPEN) return;
-                client.send(frame, { binary: true });
-                count++;
+            this.syncing.add(client);
+            try {
+                for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
+                    from,
+                    to,
+                    filterSpent,
+                )) {
+                    if (client.readyState !== WebSocket.OPEN) return; // client gone
+                    await this.awaitDrain(client);
+                    if (client.readyState !== WebSocket.OPEN) return;
+                    client.send(frame, { binary: true });
+                    count++;
+                }
+            } finally {
+                this.syncing.delete(client);
             }
 
             this.sendControl(client, 'synced', { from, to, tip, count });
@@ -116,6 +131,7 @@ export class SilentBlocksGateway
 
     broadcastSilentBlock(silentBlock: Buffer) {
         for (const client of this.server.clients) {
+            if (this.syncing.has(client)) continue;
             if (client.readyState === WebSocket.OPEN) {
                 client.send(silentBlock);
             }

--- a/src/silent-blocks/silent-blocks.gateway.ts
+++ b/src/silent-blocks/silent-blocks.gateway.ts
@@ -20,6 +20,12 @@ const MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
 // the kernel has not yet given up on (half-open connections retry for minutes).
 const STALL_TIMEOUT_MS = 60_000;
 
+// Extra passes handleSync will make to pick up blocks indexed while it was
+// streaming. Bounded so a client syncing during a fast catch-up (regtest, IBD)
+// can't hold the socket indefinitely — it just gets a `synced` ack whose `tip`
+// is above `to` and syncs again.
+const MAX_CATCHUP_ROUNDS = 3;
+
 interface SyncRequest {
     from?: number;
     to?: number;
@@ -93,7 +99,7 @@ export class SilentBlocksGateway
                 return;
             }
 
-            const tip =
+            let tip =
                 await this.silentBlocksService.getLatestIndexedBlockHeight();
             if (data?.to != null && !Number.isInteger(data.to)) {
                 this.sendControl(client, 'error', {
@@ -101,7 +107,7 @@ export class SilentBlocksGateway
                 });
                 return;
             }
-            const to = Math.min(data?.to ?? tip, tip);
+            let to = Math.min(data?.to ?? tip, tip);
             // `?? true` alone would keep the truthy string "false".
             const filterSpent = String(data?.filterSpent ?? true) !== 'false';
 
@@ -111,19 +117,42 @@ export class SilentBlocksGateway
                 return;
             }
 
+            // A block indexed while we stream falls past `to`, and
+            // broadcastSilentBlock skips this client for as long as it's in
+            // `syncing` — so it would be dropped with no signal. Re-read the
+            // tip after each pass and stream the delta. Nothing awaits between
+            // the final tip read and `syncing.delete` in the `finally`, so a
+            // broadcast can't slip through that gap.
             let count = 0;
-            for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
-                from,
-                to,
-                filterSpent,
-            )) {
-                if (client.readyState !== WebSocket.OPEN) return; // client gone
-                await this.awaitDrain(client);
-                if (client.readyState !== WebSocket.OPEN) return;
-                client.send(frame, { binary: true });
-                count++;
+            let cursor = from;
+
+            let round = 0;
+
+            for (;;) {
+                for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
+                    cursor,
+                    to,
+                    filterSpent,
+                )) {
+                    if (client.readyState !== WebSocket.OPEN) return; // client gone
+                    await this.awaitDrain(client);
+                    if (client.readyState !== WebSocket.OPEN) return;
+                    client.send(frame, { binary: true });
+                    count++;
+                }
+
+                cursor = to + 1;
+                tip =
+                    await this.silentBlocksService.getLatestIndexedBlockHeight();
+                const nextTo = Math.min(data?.to ?? tip, tip);
+                // `to` only moves when another pass will actually run, so the
+                // ack never claims a height we didn't stream.
+                if (nextTo < cursor || ++round > MAX_CATCHUP_ROUNDS) break;
+                to = nextTo;
             }
 
+            // `to < tip` here means the rounds ran out — the ack tells the
+            // client it's still behind so it can sync again.
             this.sendControl(client, 'synced', { from, to, tip, count });
         } catch (err) {
             this.logger.error(

--- a/src/silent-blocks/silent-blocks.gateway.ts
+++ b/src/silent-blocks/silent-blocks.gateway.ts
@@ -1,11 +1,25 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import {
     WebSocketGateway,
     WebSocketServer,
     OnGatewayConnection,
     OnGatewayDisconnect,
+    SubscribeMessage,
+    MessageBody,
+    ConnectedSocket,
 } from '@nestjs/websockets';
 import { Server, WebSocket } from 'ws';
+import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
+
+// Pause the height cursor while the socket's outbound buffer is above this, so a
+// slow client can't make the server buffer the whole range in memory.
+const MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
+
+interface SyncRequest {
+    from?: number;
+    to?: number;
+    filterSpent?: boolean;
+}
 
 @Injectable()
 @WebSocketGateway()
@@ -15,6 +29,11 @@ export class SilentBlocksGateway
     private readonly logger = new Logger(SilentBlocksGateway.name);
 
     @WebSocketServer() server: Server;
+
+    constructor(
+        @Inject(forwardRef(() => SilentBlocksService))
+        private readonly silentBlocksService: SilentBlocksService,
+    ) {}
 
     handleConnection(client: WebSocket) {
         const remoteAddress = (client as any)._socket.remoteAddress;
@@ -26,11 +45,90 @@ export class SilentBlocksGateway
         this.logger.debug(`Client disconnected: ${remoteAddress}`);
     }
 
+    /**
+     * Stream a contiguous range of binary silent blocks over the socket.
+     *
+     * Control in (text): { event: 'sync', data: { from, to?, filterSpent? } }
+     * Data out (binary): one `height|len|blob` frame per message.
+     * Done out (text):   { event: 'synced', data: { from, to, tip, count } }
+     * Error out (text):  { event: 'error',  data: { message } }
+     *
+     * One connection carries the whole backfill, so the ~1.5s tunnel round-trip is
+     * paid once per sync session instead of once per 200-block chunk.
+     */
+    @SubscribeMessage('sync')
+    async handleSync(
+        @ConnectedSocket() client: WebSocket,
+        @MessageBody() data: SyncRequest,
+    ): Promise<void> {
+        try {
+            const from = Math.floor(Number(data?.from));
+            if (!Number.isFinite(from) || from < 0) {
+                this.sendControl(client, 'error', {
+                    message: 'sync requires a non-negative integer `from`',
+                });
+                return;
+            }
+
+            const tip =
+                await this.silentBlocksService.getLatestIndexedBlockHeight();
+            const requestedTo =
+                data?.to != null ? Math.floor(Number(data.to)) : tip;
+            const to = Math.min(requestedTo, tip);
+            const filterSpent = data?.filterSpent ?? true;
+
+            if (to < from) {
+                // Nothing to send (client already at/above tip) — still ack.
+                this.sendControl(client, 'synced', { from, to, tip, count: 0 });
+                return;
+            }
+
+            let count = 0;
+            for await (const frame of this.silentBlocksService.streamSilentBlocksRange(
+                from,
+                to,
+                filterSpent,
+            )) {
+                if (client.readyState !== WebSocket.OPEN) return; // client gone
+                await this.awaitDrain(client);
+                if (client.readyState !== WebSocket.OPEN) return;
+                client.send(frame, { binary: true });
+                count++;
+            }
+
+            this.sendControl(client, 'synced', { from, to, tip, count });
+        } catch (err) {
+            this.logger.error(
+                `sync stream failed: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            this.sendControl(client, 'error', {
+                message: err instanceof Error ? err.message : 'sync failed',
+            });
+        }
+    }
+
     broadcastSilentBlock(silentBlock: Buffer) {
         for (const client of this.server.clients) {
             if (client.readyState === WebSocket.OPEN) {
                 client.send(silentBlock);
             }
+        }
+    }
+
+    private sendControl(client: WebSocket, event: string, data: unknown): void {
+        if (client.readyState === WebSocket.OPEN) {
+            client.send(JSON.stringify({ event, data }));
+        }
+    }
+
+    private async awaitDrain(client: WebSocket): Promise<void> {
+        while (
+            client.readyState === WebSocket.OPEN &&
+            client.bufferedAmount > MAX_BUFFERED_BYTES
+        ) {
+            await new Promise((resolve) => setTimeout(resolve, 5));
         }
     }
 }

--- a/src/silent-blocks/silent-blocks.gateway.ts
+++ b/src/silent-blocks/silent-blocks.gateway.ts
@@ -15,6 +15,11 @@ import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
 // slow client can't make the server buffer the whole range in memory.
 const MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
 
+// A client that drains nothing at all for this long is treated as dead. Any
+// progress at all drops it under the threshold, so this only catches sockets
+// the kernel has not yet given up on (half-open connections retry for minutes).
+const STALL_TIMEOUT_MS = 60_000;
+
 interface SyncRequest {
     from?: number;
     to?: number;
@@ -144,12 +149,25 @@ export class SilentBlocksGateway
         }
     }
 
+    // The deadline is per call, so a slow-but-progressing client gets a fresh
+    // budget for every frame; only a total stall runs it out.
     private async awaitDrain(client: WebSocket): Promise<void> {
+        const deadline = Date.now() + STALL_TIMEOUT_MS;
+        let delay = 5;
+
         while (
             client.readyState === WebSocket.OPEN &&
             client.bufferedAmount > MAX_BUFFERED_BYTES
         ) {
-            await new Promise((resolve) => setTimeout(resolve, 5));
+            if (Date.now() > deadline) {
+                this.logger.warn(
+                    `Terminating client stalled at ${client.bufferedAmount} buffered bytes for ${STALL_TIMEOUT_MS}ms`,
+                );
+                client.terminate();
+                return;
+            }
+            await new Promise((resolve) => setTimeout(resolve, delay));
+            delay = Math.min(delay * 2, 100);
         }
     }
 }

--- a/src/silent-blocks/silent-blocks.module.ts
+++ b/src/silent-blocks/silent-blocks.module.ts
@@ -4,9 +4,10 @@ import { SilentBlocksController } from '@/silent-blocks/silent-blocks.controller
 import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
 import { SilentBlocksGateway } from '@/silent-blocks/silent-blocks.gateway';
 import { BlockStateModule } from '@/block-state/block-state.module';
+import { DbTransactionModule } from '@/db-transaction/db-transaction.module';
 
 @Module({
-    imports: [TransactionsModule, BlockStateModule],
+    imports: [TransactionsModule, BlockStateModule, DbTransactionModule],
     providers: [SilentBlocksService, SilentBlocksGateway],
     controllers: [SilentBlocksController],
     exports: [SilentBlocksService],

--- a/src/silent-blocks/silent-blocks.service.spec.ts
+++ b/src/silent-blocks/silent-blocks.service.spec.ts
@@ -154,7 +154,7 @@ describe('SilentBlocksService', () => {
         expect(encodedBlock.toString('hex')).toEqual('0000');
     });
 
-    it('should return correct framed data from getSilentBlocksRange', async () => {
+    it('should return correct framed data from streamSilentBlocksRange', async () => {
         const fixture = silentBlockEncodingFixture[0];
 
         const batch = storageService.createBatch();
@@ -183,12 +183,16 @@ describe('SilentBlocksService', () => {
             blockHash: fixture.blockHash,
         });
 
-        const result = await service.getSilentBlocksRange(
+        const frames: Buffer[] = [];
+        for await (const frame of service.streamSilentBlocksRange(
             fixture.blockHeight,
             fixture.blockHeight,
-        );
+        )) {
+            frames.push(frame);
+        }
 
-        // Parse the frame: height (4B) + length (4B) + blob
+        expect(frames.length).toBe(1);
+        const result = frames[0];
         const frameHeight = result.readUInt32BE(0);
         const frameLength = result.readUInt32BE(4);
         const frameBlob = result.subarray(8, 8 + frameLength);

--- a/src/silent-blocks/silent-blocks.service.spec.ts
+++ b/src/silent-blocks/silent-blocks.service.spec.ts
@@ -6,6 +6,7 @@ import { silentBlockEncodingFixture } from '@/silent-blocks/silent-blocks.servic
 import { SilentBlocksGateway } from '@/silent-blocks/silent-blocks.gateway';
 import { BlockStateService } from '@/block-state/block-state.service';
 import { StorageService } from '@/storage/storage.service';
+import { DbTransactionService } from '@/db-transaction/db-transaction.service';
 import { ConfigService } from '@nestjs/config';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -14,6 +15,7 @@ import * as os from 'os';
 describe('SilentBlocksService', () => {
     let service: SilentBlocksService;
     let storageService: StorageService;
+    let blockStateService: { getCurrentBlockState: jest.Mock };
     let tmpDir: string;
 
     beforeEach(async () => {
@@ -25,6 +27,7 @@ describe('SilentBlocksService', () => {
                 SilentBlocksService,
                 TransactionsService,
                 StorageService,
+                DbTransactionService,
                 {
                     provide: ConfigService,
                     useValue: {
@@ -49,6 +52,7 @@ describe('SilentBlocksService', () => {
 
         storageService = module.get<StorageService>(StorageService);
         await storageService.onModuleInit();
+        blockStateService = module.get(BlockStateService);
         service = module.get<SilentBlocksService>(SilentBlocksService);
     });
 
@@ -148,6 +152,52 @@ describe('SilentBlocksService', () => {
         );
 
         expect(encodedBlock.toString('hex')).toEqual('0000');
+    });
+
+    it('should repair a corrupt silent block blob during backfill', async () => {
+        const fixture = silentBlockEncodingFixture[0];
+        const { blockHeight, blockHash, encodedBlockHex } = fixture;
+
+        // Seed canonical tx data + block state (the tip), then plant a corrupt
+        // blob for the height (as an older buggy encoder would have written).
+        const batch = storageService.createBatch();
+        for (const tx of fixture.transactions) {
+            storageService.saveTransaction(batch, {
+                ...tx,
+                outputs: tx.outputs.map((o) => ({
+                    ...o,
+                    transactionId: tx.id,
+                })),
+            });
+        }
+        storageService.saveBlockState(batch, { blockHeight, blockHash });
+        storageService.saveSilentBlock(
+            batch,
+            blockHeight,
+            Buffer.from('deadbeef', 'hex'),
+        );
+        await batch.commit();
+
+        blockStateService.getCurrentBlockState.mockResolvedValue({
+            blockHeight,
+            blockHash,
+        });
+
+        // Run the (private) backfill directly.
+        await (
+            service as unknown as {
+                backfillSilentBlocks: () => Promise<void>;
+            }
+        ).backfillSilentBlocks();
+
+        const repaired = storageService.getSilentBlock(blockHeight);
+        expect(repaired?.toString('hex')).toEqual(encodedBlockHex);
+
+        // The repair marker is set so the heavy pass runs only once.
+        const marker = await storageService.getOperationState(
+            'silent-block-repair',
+        );
+        expect(marker?.state?.version).toBe(1);
     });
 
     afterEach(async () => {

--- a/src/silent-blocks/silent-blocks.service.spec.ts
+++ b/src/silent-blocks/silent-blocks.service.spec.ts
@@ -3,6 +3,7 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { TransactionsService } from '@/transactions/transactions.service';
 import { SilentBlocksService } from '@/silent-blocks/silent-blocks.service';
 import { silentBlockEncodingFixture } from '@/silent-blocks/silent-blocks.service.fixtures';
+import { encodeSilentBlock } from '@/silent-blocks/silent-block-encoder';
 import { SilentBlocksGateway } from '@/silent-blocks/silent-blocks.gateway';
 import { BlockStateService } from '@/block-state/block-state.service';
 import { StorageService } from '@/storage/storage.service';
@@ -152,6 +153,22 @@ describe('SilentBlocksService', () => {
         );
 
         expect(encodedBlock.toString('hex')).toEqual('0000');
+    });
+
+    it('should encode a silent block identically regardless of input order', () => {
+        const txs = silentBlockEncodingFixture[0].transactions.map((tx) => ({
+            ...tx,
+            outputs: tx.outputs.map((o) => ({ ...o, transactionId: tx.id })),
+        }));
+        expect(txs.length).toBeGreaterThan(1);
+
+        const forward = encodeSilentBlock(txs);
+        const reversed = encodeSilentBlock([...txs].reverse());
+
+        expect(reversed.toString('hex')).toEqual(forward.toString('hex'));
+        expect(txs[0].id).toEqual(
+            silentBlockEncodingFixture[0].transactions[0].id,
+        );
     });
 
     it('should return correct framed data from streamSilentBlocksRange', async () => {

--- a/src/silent-blocks/silent-blocks.service.spec.ts
+++ b/src/silent-blocks/silent-blocks.service.spec.ts
@@ -234,6 +234,47 @@ describe('SilentBlocksService', () => {
         expect(frame.subarray(8)).toEqual(blob);
     });
 
+    it('should skip empty heights in streamSilentBlocksRange', async () => {
+        const fixture = silentBlockEncodingFixture[0];
+        const nonEmptyHeight = fixture.blockHeight;
+        const emptyHeightBefore = nonEmptyHeight - 1;
+        const emptyHeightAfter = nonEmptyHeight + 1;
+
+        const batch = storageService.createBatch();
+        // Store a non-empty blob for one height.
+        storageService.saveSilentBlock(
+            batch,
+            nonEmptyHeight,
+            Buffer.from(fixture.encodedBlockHex, 'hex'),
+        );
+        // Store explicit empty blobs (type + varint(0) = 2 bytes) for neighbour heights.
+        const emptyBlob = Buffer.from([0x00, 0x00]);
+        storageService.saveSilentBlock(batch, emptyHeightBefore, emptyBlob);
+        storageService.saveSilentBlock(batch, emptyHeightAfter, emptyBlob);
+        storageService.saveBlockState(batch, {
+            blockHeight: emptyHeightAfter,
+            blockHash: fixture.blockHash,
+        });
+        await batch.commit();
+
+        blockStateService.getCurrentBlockState.mockResolvedValue({
+            blockHeight: emptyHeightAfter,
+            blockHash: fixture.blockHash,
+        });
+
+        const frames: Buffer[] = [];
+        for await (const frame of service.streamSilentBlocksRange(
+            emptyHeightBefore,
+            emptyHeightAfter,
+        )) {
+            frames.push(frame);
+        }
+
+        // Only the non-empty height should produce a frame.
+        expect(frames.length).toBe(1);
+        expect(frames[0].readUInt32BE(0)).toBe(nonEmptyHeight);
+    });
+
     it('should repair a corrupt silent block blob during backfill', async () => {
         const fixture = silentBlockEncodingFixture[0];
         const { blockHeight, blockHash, encodedBlockHex } = fixture;

--- a/src/silent-blocks/silent-blocks.service.spec.ts
+++ b/src/silent-blocks/silent-blocks.service.spec.ts
@@ -154,6 +154,82 @@ describe('SilentBlocksService', () => {
         expect(encodedBlock.toString('hex')).toEqual('0000');
     });
 
+    it('should return correct framed data from getSilentBlocksRange', async () => {
+        const fixture = silentBlockEncodingFixture[0];
+
+        const batch = storageService.createBatch();
+        for (const tx of fixture.transactions) {
+            storageService.saveTransaction(batch, {
+                ...tx,
+                outputs: tx.outputs.map((o) => ({
+                    ...o,
+                    transactionId: tx.id,
+                })),
+            });
+        }
+        storageService.saveSilentBlock(
+            batch,
+            fixture.blockHeight,
+            Buffer.from(fixture.encodedBlockHex, 'hex'),
+        );
+        storageService.saveBlockState(batch, {
+            blockHeight: fixture.blockHeight,
+            blockHash: fixture.blockHash,
+        });
+        await batch.commit();
+
+        blockStateService.getCurrentBlockState.mockResolvedValue({
+            blockHeight: fixture.blockHeight,
+            blockHash: fixture.blockHash,
+        });
+
+        const result = await service.getSilentBlocksRange(
+            fixture.blockHeight,
+            fixture.blockHeight,
+        );
+
+        // Parse the frame: height (4B) + length (4B) + blob
+        const frameHeight = result.readUInt32BE(0);
+        const frameLength = result.readUInt32BE(4);
+        const frameBlob = result.subarray(8, 8 + frameLength);
+
+        expect(frameHeight).toBe(fixture.blockHeight);
+        expect(frameBlob.toString('hex')).toBe(fixture.encodedBlockHex);
+    });
+
+    it('should yield individual frames from streamSilentBlocksRange', async () => {
+        const fixture = silentBlockEncodingFixture[0];
+        const blob = Buffer.from(fixture.encodedBlockHex, 'hex');
+
+        const batch = storageService.createBatch();
+        storageService.saveSilentBlock(batch, fixture.blockHeight, blob);
+        storageService.saveBlockState(batch, {
+            blockHeight: fixture.blockHeight,
+            blockHash: fixture.blockHash,
+        });
+        await batch.commit();
+
+        blockStateService.getCurrentBlockState.mockResolvedValue({
+            blockHeight: fixture.blockHeight,
+            blockHash: fixture.blockHash,
+        });
+
+        const frames: Buffer[] = [];
+        for await (const frame of service.streamSilentBlocksRange(
+            fixture.blockHeight,
+            fixture.blockHeight,
+        )) {
+            frames.push(frame);
+        }
+
+        // Each frame is: height (4B) + length (4B) + blob
+        expect(frames.length).toBe(1);
+        const frame = frames[0];
+        expect(frame.readUInt32BE(0)).toBe(fixture.blockHeight);
+        expect(frame.readUInt32BE(4)).toBe(blob.length);
+        expect(frame.subarray(8)).toEqual(blob);
+    });
+
     it('should repair a corrupt silent block blob during backfill', async () => {
         const fixture = silentBlockEncodingFixture[0];
         const { blockHeight, blockHash, encodedBlockHex } = fixture;

--- a/src/silent-blocks/silent-blocks.service.ts
+++ b/src/silent-blocks/silent-blocks.service.ts
@@ -223,12 +223,24 @@ export class SilentBlocksService implements OnModuleInit {
             }
 
             for (let h = batchStart; h <= batchEnd; h++) {
-                // filterSpent=false: cache miss falls back to single-height fetch.
-                // filterSpent=true:  heights absent from the map have no unspent
-                //                    outputs; getSilentBlockByHeight encodes an empty block.
-                const blob =
-                    blobsByHeight.get(h) ??
-                    (await this.getSilentBlockByHeight(h, filterSpent));
+                let blob = blobsByHeight.get(h);
+
+                if (!blob) {
+                    if (filterSpent) {
+                        // filterSpent=true: blobsByHeight is built from txsByHeight
+                        // which only contains heights with unspent SP outputs. Absent
+                        // means nothing to scan — skip the frame entirely.
+                        continue;
+                    }
+                    // filterSpent=false: blob store miss; fall back to single-height fetch.
+                    blob = await this.getSilentBlockByHeight(h, filterSpent);
+                }
+
+                // An empty silent block encodes to exactly 2 bytes (type + varint(0)).
+                // Sending it wastes bandwidth and forces a client microtask per block;
+                // the client learns the range was clean from the final `synced` ACK.
+                if (blob.length <= 2) continue;
+
                 const header = Buffer.alloc(8);
                 header.writeUInt32BE(h, 0);
                 header.writeUInt32BE(blob.length, 4);

--- a/src/silent-blocks/silent-blocks.service.ts
+++ b/src/silent-blocks/silent-blocks.service.ts
@@ -70,11 +70,13 @@ export class SilentBlocksService implements OnModuleInit {
 
         let written = 0;
 
-        // One height at a time: read, encode and commit run with no awaited
-        // yield between them, so a concurrent indexer or reorg write can't be
-        // clobbered by a stale encoding. The yield goes after the commit, which
-        // also keeps these synchronous scans from starving the indexer and the
-        // HTTP server.
+        // One height at a time. This used to encode 100 heights, yield, then
+        // write them all, so a whole batch of encodings could go stale and
+        // clobber writes committed during the yield. Read -> encode -> commit
+        // per height keeps that window to a single height, and a height the
+        // indexer rewrites underneath us is re-saved by its own processBlock.
+        // The explicit yield goes after the commit, so these synchronous scans
+        // don't starve the indexer and the HTTP server.
         for (let height = startHeight; height <= tipHeight; height++) {
             const existing = this.storageService.getSilentBlock(height);
 

--- a/src/silent-blocks/silent-blocks.service.ts
+++ b/src/silent-blocks/silent-blocks.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import {
+    forwardRef,
+    Inject,
+    Injectable,
+    Logger,
+    OnModuleInit,
+} from '@nestjs/common';
 import { TransactionsService } from '@/transactions/transactions.service';
 import { SilentBlocksGateway } from '@/silent-blocks/silent-blocks.gateway';
 import { OnEvent } from '@nestjs/event-emitter';
@@ -7,8 +13,14 @@ import { BlockStateService } from '@/block-state/block-state.service';
 import { StorageService } from '@/storage/storage.service';
 import { DbTransactionService } from '@/db-transaction/db-transaction.service';
 import { encodeSilentBlock } from '@/silent-blocks/silent-block-encoder';
+import { TransactionData } from '@/storage/interfaces';
 
 const BACKFILL_BATCH_SIZE = 100;
+
+// Heights processed per DB scan inside streamSilentBlocksRange. Small enough that
+// the first frame is emitted quickly (low TTFB, keeps the proxy connection warm),
+// large enough to amortise the range-scan cost.
+const SILENT_BLOCK_STREAM_SUB_BATCH = 20;
 
 // Operation-state id + version gating the one-time repair pass. Bump the
 // version whenever a fix to the silent block encoding requires existing
@@ -22,6 +34,7 @@ export class SilentBlocksService implements OnModuleInit {
 
     constructor(
         private readonly transactionsService: TransactionsService,
+        @Inject(forwardRef(() => SilentBlocksGateway))
         private readonly silentBlocksGateway: SilentBlocksGateway,
         private readonly blockStateService: BlockStateService,
         private readonly storageService: StorageService,
@@ -157,54 +170,70 @@ export class SilentBlocksService implements OnModuleInit {
         return encodeSilentBlock(transactions);
     }
 
-    /**
-     * Returns a framed binary buffer containing silent blocks for each height in
-     * [startHeight, endHeight]. Each frame: height (4B BE) | byteLength (4B BE) | silentBlockBytes.
-     */
-    async getSilentBlocksRange(
-        startHeight: number,
-        endHeight: number,
-    ): Promise<Buffer> {
-        const blobs = this.storageService.getSilentBlocksRange(
-            startHeight,
-            endHeight,
-        );
-
-        const blobsByHeight = new Map(blobs.map((b) => [b.height, b.blob]));
-        const frames: Buffer[] = [];
-
-        for (let h = startHeight; h <= endHeight; h++) {
-            const blob =
-                blobsByHeight.get(h) ??
-                (await this.getSilentBlockByHeight(h, false));
-            const header = Buffer.alloc(8);
-            header.writeUInt32BE(h, 0);
-            header.writeUInt32BE(blob.length, 4);
-            frames.push(header, blob);
-        }
-
-        return Buffer.concat(frames);
-    }
-
     async *streamSilentBlocksRange(
         startHeight: number,
         endHeight: number,
+        filterSpent = false,
     ): AsyncGenerator<Buffer> {
-        const blobs = this.storageService.getSilentBlocksRange(
-            startHeight,
-            endHeight,
-        );
+        // Emit incrementally in small sub-batches rather than scanning the whole
+        // span up front. The first frame leaves the origin after one sub-batch
+        // (~tens of ms) instead of after the entire range, which keeps the proxy
+        // connection fed (no idle-timeout 502s on filterSpent ranges) and lets the
+        // client pipeline against its scan. Frame bytes are identical either way.
+        for (
+            let batchStart = startHeight;
+            batchStart <= endHeight;
+            batchStart += SILENT_BLOCK_STREAM_SUB_BATCH
+        ) {
+            const batchEnd = Math.min(
+                batchStart + SILENT_BLOCK_STREAM_SUB_BATCH - 1,
+                endHeight,
+            );
 
-        const blobsByHeight = new Map(blobs.map((b) => [b.height, b.blob]));
+            // filterSpent=false: serve from blob store, fall back per-height on miss.
+            // filterSpent=true:  bulk-fetch the sub-batch's txs in one range scan,
+            //                    group by height, encode per block.
+            const blobsByHeight = new Map<number, Buffer>();
 
-        for (let h = startHeight; h <= endHeight; h++) {
-            const blob =
-                blobsByHeight.get(h) ??
-                (await this.getSilentBlockByHeight(h, false));
-            const header = Buffer.alloc(8);
-            header.writeUInt32BE(h, 0);
-            header.writeUInt32BE(blob.length, 4);
-            yield Buffer.concat([header, blob]);
+            if (!filterSpent) {
+                const blobs = this.storageService.getSilentBlocksRange(
+                    batchStart,
+                    batchEnd,
+                );
+                for (const { height, blob } of blobs) {
+                    blobsByHeight.set(height, blob);
+                }
+            } else {
+                const txs =
+                    await this.transactionsService.getTransactionsByBlockHeightRange(
+                        batchStart,
+                        batchEnd,
+                        true,
+                    );
+                // Group transactions by block height
+                const txsByHeight = new Map<number, TransactionData[]>();
+                for (const tx of txs) {
+                    const list = txsByHeight.get(tx.blockHeight) ?? [];
+                    list.push(tx);
+                    txsByHeight.set(tx.blockHeight, list);
+                }
+                for (const [height, blockTxs] of txsByHeight) {
+                    blobsByHeight.set(height, encodeSilentBlock(blockTxs));
+                }
+            }
+
+            for (let h = batchStart; h <= batchEnd; h++) {
+                // filterSpent=false: cache miss falls back to single-height fetch.
+                // filterSpent=true:  heights absent from the map have no unspent
+                //                    outputs; getSilentBlockByHeight encodes an empty block.
+                const blob =
+                    blobsByHeight.get(h) ??
+                    (await this.getSilentBlockByHeight(h, filterSpent));
+                const header = Buffer.alloc(8);
+                header.writeUInt32BE(h, 0);
+                header.writeUInt32BE(blob.length, 4);
+                yield Buffer.concat([header, blob]);
+            }
         }
     }
 

--- a/src/silent-blocks/silent-blocks.service.ts
+++ b/src/silent-blocks/silent-blocks.service.ts
@@ -186,6 +186,28 @@ export class SilentBlocksService implements OnModuleInit {
         return Buffer.concat(frames);
     }
 
+    async *streamSilentBlocksRange(
+        startHeight: number,
+        endHeight: number,
+    ): AsyncGenerator<Buffer> {
+        const blobs = this.storageService.getSilentBlocksRange(
+            startHeight,
+            endHeight,
+        );
+
+        const blobsByHeight = new Map(blobs.map((b) => [b.height, b.blob]));
+
+        for (let h = startHeight; h <= endHeight; h++) {
+            const blob =
+                blobsByHeight.get(h) ??
+                (await this.getSilentBlockByHeight(h, false));
+            const header = Buffer.alloc(8);
+            header.writeUInt32BE(h, 0);
+            header.writeUInt32BE(blob.length, 4);
+            yield Buffer.concat([header, blob]);
+        }
+    }
+
     async getLatestIndexedBlockHeight(): Promise<number> {
         const currentBlockState =
             await this.blockStateService.getCurrentBlockState();

--- a/src/silent-blocks/silent-blocks.service.ts
+++ b/src/silent-blocks/silent-blocks.service.ts
@@ -15,8 +15,6 @@ import { DbTransactionService } from '@/db-transaction/db-transaction.service';
 import { encodeSilentBlock } from '@/silent-blocks/silent-block-encoder';
 import { TransactionData } from '@/storage/interfaces';
 
-const BACKFILL_BATCH_SIZE = 100;
-
 // type + varint(0)
 const EMPTY_SILENT_BLOCK_LENGTH = 2;
 
@@ -72,27 +70,16 @@ export class SilentBlocksService implements OnModuleInit {
 
         let written = 0;
 
-        for (let h = startHeight; h <= tipHeight; h += BACKFILL_BATCH_SIZE) {
-            const batchEnd = Math.min(h + BACKFILL_BATCH_SIZE - 1, tipHeight);
-            const existingBlobs = this.storageService.getSilentBlocksRange(
-                h,
-                batchEnd,
-            );
-            const existingByHeight = new Map(
-                existingBlobs.map((b) => [b.height, b.blob]),
-            );
+        // One height at a time: read, encode and commit run with no awaited
+        // yield between them, so a concurrent indexer or reorg write can't be
+        // clobbered by a stale encoding. The yield goes after the commit, which
+        // also keeps these synchronous scans from starving the indexer and the
+        // HTTP server.
+        for (let height = startHeight; height <= tipHeight; height++) {
+            const existing = this.storageService.getSilentBlock(height);
 
-            const pending: { height: number; blob: Buffer }[] = [];
-            for (let height = h; height <= batchEnd; height++) {
-                const existing = existingByHeight.get(height);
-
-                // Gap-fill mode trusts a present blob and skips re-encoding.
-                if (existing && !repair) continue;
-
-                // An empty block is byte-identical on every encoder version, so
-                // repair has nothing to fix and can skip the scan.
-                if (existing?.length === EMPTY_SILENT_BLOCK_LENGTH) continue;
-
+            // Gap-fill mode trusts a present blob and skips re-encoding.
+            if (!existing || repair) {
                 const txs =
                     await this.storageService.getTransactionsByBlockHeight(
                         height,
@@ -101,22 +88,18 @@ export class SilentBlocksService implements OnModuleInit {
                 const fresh = encodeSilentBlock(txs);
 
                 if (!existing || !existing.equals(fresh)) {
-                    pending.push({ height, blob: fresh });
+                    await this.dbTransactionService.execute(async (batch) => {
+                        this.storageService.saveSilentBlock(
+                            batch,
+                            height,
+                            fresh,
+                        );
+                    });
+                    written++;
                 }
             }
 
-            // The scans above are synchronous; yield so the backfill can't
-            // starve the indexer or the HTTP server.
             await new Promise((resolve) => setImmediate(resolve));
-
-            if (pending.length === 0) continue;
-
-            await this.dbTransactionService.execute(async (batch) => {
-                for (const { height, blob } of pending) {
-                    this.storageService.saveSilentBlock(batch, height, blob);
-                    written++;
-                }
-            });
         }
 
         // Mark the repair done only after a full successful pass; a crash

--- a/src/silent-blocks/silent-blocks.service.ts
+++ b/src/silent-blocks/silent-blocks.service.ts
@@ -1,22 +1,120 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { TransactionData } from '@/storage/interfaces';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { TransactionsService } from '@/transactions/transactions.service';
-import { SILENT_PAYMENT_BLOCK_TYPE } from '@/common/constants';
-import { encodeVarInt, varIntSize } from '@/common/common';
 import { SilentBlocksGateway } from '@/silent-blocks/silent-blocks.gateway';
 import { OnEvent } from '@nestjs/event-emitter';
 import { INDEXED_BLOCK_EVENT } from '@/common/events';
 import { BlockStateService } from '@/block-state/block-state.service';
+import { StorageService } from '@/storage/storage.service';
+import { DbTransactionService } from '@/db-transaction/db-transaction.service';
+import { encodeSilentBlock } from '@/silent-blocks/silent-block-encoder';
+
+const BACKFILL_BATCH_SIZE = 100;
+
+// Operation-state id + version gating the one-time repair pass. Bump the
+// version whenever a fix to the silent block encoding requires existing
+// blobs to be rewritten from canonical tx data.
+const SILENT_BLOCK_REPAIR_STATE = 'silent-block-repair';
+const SILENT_BLOCK_REPAIR_VERSION = 1;
 
 @Injectable()
-export class SilentBlocksService {
+export class SilentBlocksService implements OnModuleInit {
     private readonly logger = new Logger(SilentBlocksService.name);
 
     constructor(
         private readonly transactionsService: TransactionsService,
         private readonly silentBlocksGateway: SilentBlocksGateway,
         private readonly blockStateService: BlockStateService,
+        private readonly storageService: StorageService,
+        private readonly dbTransactionService: DbTransactionService,
     ) {}
+
+    onModuleInit() {
+        this.backfillSilentBlocks().catch((err) =>
+            this.logger.error(`Silent block backfill failed: ${err.message}`),
+        );
+    }
+
+    private async backfillSilentBlocks(): Promise<void> {
+        const tip = await this.blockStateService.getCurrentBlockState();
+        if (!tip) return;
+
+        const startHeight = this.storageService.getLowestBlockStateHeight();
+        if (startHeight === null) return;
+
+        const tipHeight = tip.blockHeight;
+
+        // In repair mode every height is re-encoded from canonical tx data and
+        // compared against the stored blob, so blobs corrupted by an older
+        // encoder are rewritten. Otherwise we only fill missing heights (cheap:
+        // trust existing blobs without re-reading tx data). The pass runs once
+        // per version, gated by an operation-state marker.
+        const repairState = await this.storageService.getOperationState(
+            SILENT_BLOCK_REPAIR_STATE,
+        );
+        const repair =
+            (repairState?.state?.version ?? 0) < SILENT_BLOCK_REPAIR_VERSION;
+
+        let written = 0;
+
+        for (let h = startHeight; h <= tipHeight; h += BACKFILL_BATCH_SIZE) {
+            const batchEnd = Math.min(h + BACKFILL_BATCH_SIZE - 1, tipHeight);
+            const existingBlobs = this.storageService.getSilentBlocksRange(
+                h,
+                batchEnd,
+            );
+            const existingByHeight = new Map(
+                existingBlobs.map((b) => [b.height, b.blob]),
+            );
+
+            const pending: { height: number; blob: Buffer }[] = [];
+            for (let height = h; height <= batchEnd; height++) {
+                const existing = existingByHeight.get(height);
+
+                // Gap-fill mode trusts a present blob and skips re-encoding.
+                if (existing && !repair) continue;
+
+                const txs =
+                    await this.storageService.getTransactionsByBlockHeight(
+                        height,
+                        false,
+                    );
+                const fresh = encodeSilentBlock(txs);
+
+                if (!existing || !existing.equals(fresh)) {
+                    pending.push({ height, blob: fresh });
+                }
+            }
+
+            if (pending.length === 0) continue;
+
+            await this.dbTransactionService.execute(async (batch) => {
+                for (const { height, blob } of pending) {
+                    this.storageService.saveSilentBlock(batch, height, blob);
+                    written++;
+                }
+            });
+        }
+
+        // Mark the repair done only after a full successful pass; a crash
+        // mid-repair leaves the marker unset so it re-runs (idempotent).
+        if (repair) {
+            const batch = this.storageService.createBatch();
+            this.storageService.saveOperationState(
+                batch,
+                SILENT_BLOCK_REPAIR_STATE,
+                { version: SILENT_BLOCK_REPAIR_VERSION },
+            );
+            await batch.commit();
+        }
+
+        if (written > 0) {
+            this.logger.log(
+                `Silent block backfill complete: ${written} blobs ${
+                    repair ? 'written/repaired' : 'written'
+                }`,
+            );
+        }
+    }
 
     @OnEvent(INDEXED_BLOCK_EVENT)
     async handleBlockIndexedEvent(blockHeight: number) {
@@ -28,51 +126,22 @@ export class SilentBlocksService {
         this.silentBlocksGateway.broadcastSilentBlock(silentBlock);
     }
 
-    private getSilentBlockLength(transactions: TransactionData[]): number {
-        let length = 1 + varIntSize(transactions.length); // 1 byte for type + varint for transactions count
-
-        for (const tx of transactions) {
-            length +=
-                65 + varIntSize(tx.outputs.length) + tx.outputs.length * 44; // 32 + varint for output count + 44 per output + 33
-        }
-
-        return length;
-    }
-
-    public encodeSilentBlock(transactions: TransactionData[]): Buffer {
-        const block = Buffer.alloc(this.getSilentBlockLength(transactions));
-        let cursor = 0;
-
-        cursor = block.writeUInt8(SILENT_PAYMENT_BLOCK_TYPE, cursor);
-        cursor = encodeVarInt(transactions.length, block, cursor);
-
-        for (const tx of transactions) {
-            cursor += block.write(tx.id, cursor, 32, 'hex');
-            cursor = encodeVarInt(tx.outputs.length, block, cursor);
-
-            for (const output of tx.outputs) {
-                cursor = block.writeBigUInt64BE(BigInt(output.value), cursor);
-                cursor += block.write(output.pubKey, cursor, 32, 'hex');
-                cursor = block.writeUInt32BE(output.vout, cursor);
-            }
-
-            cursor += block.write(tx.scanTweak, cursor, 33, 'hex');
-        }
-
-        return block;
-    }
-
     async getSilentBlockByHeight(
         blockHeight: number,
         filterSpent: boolean,
     ): Promise<Buffer> {
+        if (!filterSpent) {
+            const blob = this.storageService.getSilentBlock(blockHeight);
+            if (blob) return blob;
+        }
+
         const transactions =
             await this.transactionsService.getTransactionByBlockHeight(
                 blockHeight,
                 filterSpent,
             );
 
-        return this.encodeSilentBlock(transactions);
+        return encodeSilentBlock(transactions);
     }
 
     async getSilentBlockByHash(
@@ -85,7 +154,36 @@ export class SilentBlocksService {
                 filterSpent,
             );
 
-        return this.encodeSilentBlock(transactions);
+        return encodeSilentBlock(transactions);
+    }
+
+    /**
+     * Returns a framed binary buffer containing silent blocks for each height in
+     * [startHeight, endHeight]. Each frame: height (4B BE) | byteLength (4B BE) | silentBlockBytes.
+     */
+    async getSilentBlocksRange(
+        startHeight: number,
+        endHeight: number,
+    ): Promise<Buffer> {
+        const blobs = this.storageService.getSilentBlocksRange(
+            startHeight,
+            endHeight,
+        );
+
+        const blobsByHeight = new Map(blobs.map((b) => [b.height, b.blob]));
+        const frames: Buffer[] = [];
+
+        for (let h = startHeight; h <= endHeight; h++) {
+            const blob =
+                blobsByHeight.get(h) ??
+                (await this.getSilentBlockByHeight(h, false));
+            const header = Buffer.alloc(8);
+            header.writeUInt32BE(h, 0);
+            header.writeUInt32BE(blob.length, 4);
+            frames.push(header, blob);
+        }
+
+        return Buffer.concat(frames);
     }
 
     async getLatestIndexedBlockHeight(): Promise<number> {

--- a/src/silent-blocks/silent-blocks.service.ts
+++ b/src/silent-blocks/silent-blocks.service.ts
@@ -17,6 +17,9 @@ import { TransactionData } from '@/storage/interfaces';
 
 const BACKFILL_BATCH_SIZE = 100;
 
+// type + varint(0)
+const EMPTY_SILENT_BLOCK_LENGTH = 2;
+
 // Heights processed per DB scan inside streamSilentBlocksRange. Small enough that
 // the first frame is emitted quickly (low TTFB, keeps the proxy connection warm),
 // large enough to amortise the range-scan cost.
@@ -86,6 +89,10 @@ export class SilentBlocksService implements OnModuleInit {
                 // Gap-fill mode trusts a present blob and skips re-encoding.
                 if (existing && !repair) continue;
 
+                // An empty block is byte-identical on every encoder version, so
+                // repair has nothing to fix and can skip the scan.
+                if (existing?.length === EMPTY_SILENT_BLOCK_LENGTH) continue;
+
                 const txs =
                     await this.storageService.getTransactionsByBlockHeight(
                         height,
@@ -97,6 +104,10 @@ export class SilentBlocksService implements OnModuleInit {
                     pending.push({ height, blob: fresh });
                 }
             }
+
+            // The scans above are synchronous; yield so the backfill can't
+            // starve the indexer or the HTTP server.
+            await new Promise((resolve) => setImmediate(resolve));
 
             if (pending.length === 0) continue;
 
@@ -232,14 +243,17 @@ export class SilentBlocksService implements OnModuleInit {
                         // means nothing to scan — skip the frame entirely.
                         continue;
                     }
-                    // filterSpent=false: blob store miss; fall back to single-height fetch.
-                    blob = await this.getSilentBlockByHeight(h, filterSpent);
+                    // filterSpent=false: blob store miss, encode from tx data.
+                    blob = encodeSilentBlock(
+                        await this.transactionsService.getTransactionByBlockHeight(
+                            h,
+                            false,
+                        ),
+                    );
                 }
 
-                // An empty silent block encodes to exactly 2 bytes (type + varint(0)).
-                // Sending it wastes bandwidth and forces a client microtask per block;
-                // the client learns the range was clean from the final `synced` ACK.
-                if (blob.length <= 2) continue;
+                // The client learns the range was clean from the `synced` ACK.
+                if (blob.length <= EMPTY_SILENT_BLOCK_LENGTH) continue;
 
                 const header = Buffer.alloc(8);
                 header.writeUInt32BE(h, 0);

--- a/src/storage/key-encoding.ts
+++ b/src/storage/key-encoding.ts
@@ -11,6 +11,31 @@ const PREFIX = {
     SILENT_BLOCK: Buffer.from('sb:'),
 } as const;
 
+// --- Height-keyed namespaces ---
+// Three namespaces key on a 4-byte big-endian height; the span upper bound is
+// exclusive, so it encodes `endHeight + 1`.
+
+function heightKey(prefix: Buffer, height: number): Buffer {
+    const heightBuf = Buffer.alloc(4);
+    heightBuf.writeUInt32BE(height);
+    return Buffer.concat([prefix, heightBuf]);
+}
+
+function heightAt(prefix: Buffer, key: Buffer): number {
+    return key.readUInt32BE(prefix.length);
+}
+
+function heightSpan(
+    prefix: Buffer,
+    startHeight: number,
+    endHeight: number,
+): { gte: Buffer; lt: Buffer } {
+    return {
+        gte: heightKey(prefix, startHeight),
+        lt: heightKey(prefix, endHeight + 1),
+    };
+}
+
 // --- Key encoders ---
 
 export function encodeTxKey(txid: string): Buffer {
@@ -63,9 +88,7 @@ export function encodeUnspentIndexKey(txid: string, vout: number): Buffer {
 }
 
 export function encodeBlockStateKey(height: number): Buffer {
-    const heightBuf = Buffer.alloc(4);
-    heightBuf.writeUInt32BE(height);
-    return Buffer.concat([PREFIX.BLOCK_STATE, heightBuf]);
+    return heightKey(PREFIX.BLOCK_STATE, height);
 }
 
 export function encodeOpStateKey(id: string): Buffer {
@@ -195,7 +218,7 @@ export function decodeUnspentIndexKey(key: Buffer): {
 }
 
 export function decodeBlockStateKey(key: Buffer): number {
-    return key.readUInt32BE(PREFIX.BLOCK_STATE.length);
+    return heightAt(PREFIX.BLOCK_STATE, key);
 }
 
 // --- Range helpers for prefix scans ---
@@ -237,13 +260,7 @@ export function singleHeightRange(height: number): {
     gte: Buffer;
     lt: Buffer;
 } {
-    const heightBuf = Buffer.alloc(4);
-    heightBuf.writeUInt32BE(height);
-    const gte = Buffer.concat([PREFIX.HEIGHT_IDX, heightBuf]);
-    const nextHeightBuf = Buffer.alloc(4);
-    nextHeightBuf.writeUInt32BE(height + 1);
-    const lt = Buffer.concat([PREFIX.HEIGHT_IDX, nextHeightBuf]);
-    return { gte, lt };
+    return heightSpan(PREFIX.HEIGHT_IDX, height, height);
 }
 
 /** Height index range: all txids across a block height span [start, end] */
@@ -251,14 +268,7 @@ export function heightSpanRange(
     startHeight: number,
     endHeight: number,
 ): { gte: Buffer; lt: Buffer } {
-    const startBuf = Buffer.alloc(4);
-    startBuf.writeUInt32BE(startHeight);
-    const endBuf = Buffer.alloc(4);
-    endBuf.writeUInt32BE(endHeight + 1);
-    return {
-        gte: Buffer.concat([PREFIX.HEIGHT_IDX, startBuf]),
-        lt: Buffer.concat([PREFIX.HEIGHT_IDX, endBuf]),
-    };
+    return heightSpan(PREFIX.HEIGHT_IDX, startHeight, endHeight);
 }
 
 /** Hash index range: all txids for a specific block hash */
@@ -319,13 +329,11 @@ export function timeIndexSeek(timestamp: number): {
 }
 
 export function encodeSilentBlockKey(height: number): Buffer {
-    const heightBuf = Buffer.alloc(4);
-    heightBuf.writeUInt32BE(height);
-    return Buffer.concat([PREFIX.SILENT_BLOCK, heightBuf]);
+    return heightKey(PREFIX.SILENT_BLOCK, height);
 }
 
 export function decodeSilentBlockKey(key: Buffer): number {
-    return key.readUInt32BE(PREFIX.SILENT_BLOCK.length);
+    return heightAt(PREFIX.SILENT_BLOCK, key);
 }
 
 /** Silent block span range: all blobs across [startHeight, endHeight] */
@@ -333,12 +341,5 @@ export function silentBlockSpanRange(
     startHeight: number,
     endHeight: number,
 ): { gte: Buffer; lt: Buffer } {
-    const startBuf = Buffer.alloc(4);
-    startBuf.writeUInt32BE(startHeight);
-    const endBuf = Buffer.alloc(4);
-    endBuf.writeUInt32BE(endHeight + 1);
-    return {
-        gte: Buffer.concat([PREFIX.SILENT_BLOCK, startBuf]),
-        lt: Buffer.concat([PREFIX.SILENT_BLOCK, endBuf]),
-    };
+    return heightSpan(PREFIX.SILENT_BLOCK, startHeight, endHeight);
 }

--- a/src/storage/key-encoding.ts
+++ b/src/storage/key-encoding.ts
@@ -8,6 +8,7 @@ const PREFIX = {
     UNSPENT_IDX: Buffer.from('idx:us:'),
     BLOCK_STATE: Buffer.from('bs:'),
     OP_STATE: Buffer.from('os:'),
+    SILENT_BLOCK: Buffer.from('sb:'),
 } as const;
 
 // --- Key encoders ---
@@ -314,5 +315,30 @@ export function timeIndexSeek(timestamp: number): {
     return {
         gte: Buffer.concat([PREFIX.TIME_IDX, timeBuf]),
         lt: prefixUpperBound(PREFIX.TIME_IDX),
+    };
+}
+
+export function encodeSilentBlockKey(height: number): Buffer {
+    const heightBuf = Buffer.alloc(4);
+    heightBuf.writeUInt32BE(height);
+    return Buffer.concat([PREFIX.SILENT_BLOCK, heightBuf]);
+}
+
+export function decodeSilentBlockKey(key: Buffer): number {
+    return key.readUInt32BE(PREFIX.SILENT_BLOCK.length);
+}
+
+/** Silent block span range: all blobs across [startHeight, endHeight] */
+export function silentBlockSpanRange(
+    startHeight: number,
+    endHeight: number,
+): { gte: Buffer; lt: Buffer } {
+    const startBuf = Buffer.alloc(4);
+    startBuf.writeUInt32BE(startHeight);
+    const endBuf = Buffer.alloc(4);
+    endBuf.writeUInt32BE(endHeight + 1);
+    return {
+        gte: Buffer.concat([PREFIX.SILENT_BLOCK, startBuf]),
+        lt: Buffer.concat([PREFIX.SILENT_BLOCK, endBuf]),
     };
 }

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -39,6 +39,9 @@ import {
     unspentPrefixRange,
     blockStateRange,
     timeIndexSeek,
+    encodeSilentBlockKey,
+    decodeSilentBlockKey,
+    silentBlockSpanRange,
 } from '@/storage/key-encoding';
 
 @Injectable()
@@ -176,6 +179,14 @@ export class StorageService implements OnModuleInit, OnModuleDestroy {
                 blockHeight: decodeBlockStateKey(key),
                 blockHash: value.toString('hex'),
             }),
+        );
+        return results.length > 0 ? results[0] : null;
+    }
+
+    getLowestBlockStateHeight(): number | null {
+        const range = blockStateRange();
+        const results = this.collectRange({ ...range, limit: 1 }, (key) =>
+            decodeBlockStateKey(key),
         );
         return results.length > 0 ? results[0] : null;
     }
@@ -348,6 +359,31 @@ export class StorageService implements OnModuleInit, OnModuleDestroy {
 
     deleteBlockState(batch: BatchWriter, height: number): void {
         batch.del(encodeBlockStateKey(height));
+    }
+
+    // --- Silent block blobs ---
+
+    saveSilentBlock(batch: BatchWriter, height: number, blob: Buffer): void {
+        batch.put(encodeSilentBlockKey(height), blob);
+    }
+
+    deleteSilentBlock(batch: BatchWriter, height: number): void {
+        batch.del(encodeSilentBlockKey(height));
+    }
+
+    getSilentBlock(height: number): Buffer | null {
+        return this.get(encodeSilentBlockKey(height));
+    }
+
+    getSilentBlocksRange(
+        startHeight: number,
+        endHeight: number,
+    ): { height: number; blob: Buffer }[] {
+        const range = silentBlockSpanRange(startHeight, endHeight);
+        return this.collectRange(range, (key, value) => ({
+            height: decodeSilentBlockKey(key),
+            blob: value,
+        }));
     }
 
     // --- Private helpers ---

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -78,8 +78,7 @@ export class StorageService implements OnModuleInit, OnModuleDestroy {
     // --- Low-level helpers ---
 
     private get(key: Buffer): Buffer | null {
-        const val = this.db.getBinary(key);
-        return val ? Buffer.from(val) : null;
+        return this.db.getBinary(key) ?? null;
     }
 
     private collectRange<T>(
@@ -96,9 +95,7 @@ export class StorageService implements OnModuleInit, OnModuleDestroy {
             limit: opts.limit,
         });
         for (const { key, value } of range) {
-            results.push(
-                decode(Buffer.from(key as any), Buffer.from(value as any)),
-            );
+            results.push(decode(key as Buffer, value as Buffer));
         }
         return results;
     }

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -1,6 +1,5 @@
 import { CacheInterceptor } from '@nestjs/cache-manager';
 import {
-    BadRequestException,
     Controller,
     Get,
     NotFoundException,
@@ -12,6 +11,7 @@ import {
 } from '@nestjs/common';
 import { TransactionsService } from '@/transactions/transactions.service';
 import { MAX_BLOCK_RANGE } from '@/common/constants';
+import { assertHeightRange } from '@/common/common';
 
 @Controller('transactions')
 export class TransactionController {
@@ -41,21 +41,7 @@ export class TransactionController {
         @Query('filterSpent', new ParseBoolPipe({ optional: true }))
         filterSpent = false,
     ) {
-        if (startHeight < 0 || endHeight < 0) {
-            throw new BadRequestException('Block heights must be non-negative');
-        }
-
-        if (startHeight > endHeight) {
-            throw new BadRequestException(
-                'startHeight must be less than or equal to endHeight',
-            );
-        }
-
-        if (endHeight - startHeight + 1 > MAX_BLOCK_RANGE) {
-            throw new BadRequestException(
-                `Range too large. Maximum allowed range is ${MAX_BLOCK_RANGE} blocks`,
-            );
-        }
+        assertHeightRange(startHeight, endHeight, MAX_BLOCK_RANGE);
 
         const transactions =
             await this.transactionsService.getTransactionsByBlockHeightRange(


### PR DESCRIPTION
## Summary

- **Streaming range endpoint**: Replace full-buffer approach with chunked byte streaming and `Cache-Control` headers.
- **Block prefetch**: Prefetch the next block in both Bitcoin Core and Esplora providers to hide RPC/HTTP latency during sequential scans
- **Binary precomputation**: Precompute and store silent block data in binary format at index time, eliminating per-request serialization
- **WebSocket streaming sync**: Add `filterSpent` support and batched binary framing to the WS gateway for efficient wallet sync
- **Keepalive**: ping/pong handler so Cloudflare does not drop an idle sync socket
- **Empty frames**: skip heights with no silent payments. Over 99% of mainnet blocks are empty, so the stream was mostly no-op frames

### Benchmark Results (tested with shroud)

| Architecture | 50-Block Sync Time | Client Throughput | Payload per 1,000 Blocks |
| :--- | :--- | :--- | :--- |
| **V1: REST JSON (`filterSpent=true`)** | ~6.00s | ~2,500 tx/sec | ~20 MB |
| **V2: REST Binary (Unfiltered)** | ~1.50s | ~16,700 tx/sec | ~58 MB |
| **V3: REST Binary (`filterSpent=true`)** | ~2.00s | ~9,500 tx/sec * | ~12 MB |
| **V4: WebSocket Binary Streaming (Current)** | **< 0.50s** | **~20,000 tx/sec** | **~12 MB** |

### Key Wins
1. **Network Pipelining:** WebSocket streaming eliminates the HTTP overhead and constant polling latency.
2. **Maximum Wasm Efficiency:** The Rust WebAssembly engine is now parsing heavily filtered UTXOs at a blistering **20,000 transactions per second**. Batch scanning consistently finishes in `~570ms` for massive 1.5MB chunks.
3. **Bandwidth Reduction:** Implementing `filterSpent=true` strictly on the binary endpoint reduced sync payload size by **~80%**, avoiding the Base64/JSON serialization tax entirely.

<img width="1197" height="664" alt="image" src="https://github.com/user-attachments/assets/1293ce6a-58d4-4ab3-ac5f-270e941bdd4c" />

### Indexer

* **Reset `lastProcessedTxIndex` after each block.** It was never reset when a block finished, causing every subsequent block to start past the end of its transaction list. Nothing was saved and the indexed height never advanced, stalling sync.
* **Persist resumed blocks correctly.** When block processing resumed mid-way, the resulting silent block could be truncated. The block is now read back from committed storage and written in its own batch.
* **Handle failed look-ahead writes.** If block `N` failed to write, the promise for block `N+1` could become orphaned and its late rejection could terminate the process.
* **Emit `INDEXED_BLOCK_EVENT` once per block.** Previously, the event fired once per transaction batch, causing a 900-tx block to broadcast 9 times, with 8 broadcasts containing partial data.
* **Sort silent blocks by txid.** Payload ordering previously depended on the producer, meaning the same block height could produce different payloads despite the bytes being served as immutable data.
* **Commit block state for every block.** A coinbase-only block runs zero transaction batches, so its height was never marked done — while the silent block was still saved and broadcast. Every restart reprocessed and re-broadcast that height. State now commits in the same batch as the blob, so the two cannot diverge.
* **Cover the whole block in the error handler.** The readback and silent block commit sat outside the `try`/`catch`, so a failure there threw without naming the height.

### HTTP

* **Validate block heights at the edge.** `/range` validated the requested span but not the height itself. Heights above `uint32` reached `writeUInt32BE` and resulted in a 500. `transactions/range` had the same issue.
* **Prevent truncated responses from being cached.** A mid-stream throw could result in a short body being returned as a successful `200` with `immutable, max-age=1y`, causing clients and CDNs to cache truncated ranges for a year. The socket is now destroyed instead.
* **Fix backpressure handling.** The backpressure helper could attach its `close` listener after the event had already fired and hang indefinitely. It also had no timeout. This is now replaced with `pipeline()` and a 60-second stall timeout, matching the WebSocket path.
* **Clamp `endHeight` to the chain tip.** Empty heights are now skipped, preventing an unindexed height from being treated the same as an empty height and causing clients to advance their cursor past it.
* **Fix caching and validation for `height/:height`.** The endpoint no longer serves immutable cache headers for the current tip. It now requires 6 confirmations, matching `/range`, and also uses `ParseIntPipe` for height validation.
* **404 an unindexed height on `height/:height`.** A height above the tip returned the same 2 bytes as a genuinely empty block, so clients read "not indexed yet" as "no payments here". `/range` already clamped for this reason.
* **Rate-limit `/range`.** This is the most expensive HTTP endpoint and previously had no rate limit.

### WebSocket

* **Allow only one sync per socket.** Concurrent sync messages on the same socket could mutate the shared syncing set at the same time and corrupt its state.
* **Prevent broadcast frames from corrupting sync parsing.** Tip broadcasts are bare blobs, while sync frames use `height | len | blob`. A broadcast arriving mid-sync could therefore desynchronize the client's frame parser. Syncing clients are now skipped for broadcasts.
* **Fix `from` parsing.** Passing `null` or `""` through `Number()` could unintentionally trigger a full sync from genesis.
* **Fix `filterSpent` parsing.** Using `??` preserved the string `"false"` as truthy, causing spent outputs to be filtered even when the client explicitly requested otherwise.
* **Bound drain waits.** The drain loop previously polled every 5ms with no upper bound, allowing a half-open connection to spin for roughly 15 minutes. It now backs off to 100ms and terminates clients that make no draining progress for 60 seconds.
* **Stop dropping blocks indexed during a sync.** `to` is fixed at sync start and broadcasts skip syncing clients, so a block indexed mid-sync was excluded from both — dropped with no signal. Sync now re-checks the tip after each pass and streams the delta, capped at 3 rounds so a client syncing during IBD cannot hold the socket. Hitting the cap acks with `tip > to`, which tells the client to sync again.

### Backfill

* **Prevent stale backfill writes.** Backfill previously encoded 100 heights, yielded, and then wrote stale bytes over data that may have been committed during that window. It now performs read → encode → commit per height, with the yield happening after the commit.

### Tests

**108 tests pass.**

## Not in this PR

* **Partial-block recovery:** If the process crashes mid-block, `lastProcessedTxIndex` can survive and cause the next block to skip its first `N` transactions. The proper fix is to avoid advancing `indexedBlockHeight` for a partially processed block, which requires a larger change than this PR.
* **WebSocket sync limits:** WS sync currently has no range cap or rate limit unlike REST. A single socket carrying the entire backfill is intentional.
* **`hash/:hash` tip check:** `height/:height` now 404s an unindexed height, but a hash carries no ordering and there is no block-hash → height index, so an unknown hash and a coinbase-only block both scan to zero rows. Distinguishing them needs a new index, not a guard.
* **`filterSpent` defaults:** WebSocket defaults to `true` while HTTP defaults to `false`. The ~12 MB payload reduction depends on the WebSocket default.



